### PR TITLE
fix: remove incorrect red background on active sidebar item

### DIFF
--- a/src/layouts/profile/AboutPanel.tsx
+++ b/src/layouts/profile/AboutPanel.tsx
@@ -141,7 +141,6 @@ const AboutPanel = ({
                 as="button"
                 isSelected={currentSection === section.type}
                 className={mergeClassnames(
-                  currentSection === section.type && 'bg-red-60 border-none',
                   section.type === 'moderations' && 'border border-red-90',
                 )}
                 onClick={() => setCurrentSection(section.type)}


### PR DESCRIPTION
## What this PR does
- [x] Fix sidebar active item hiển thị màu đỏ (`bg-red-60`) thay vì màu đúng khi được chọn
- [x] Tested in LOCAL

## Related Issue
Closes #443

## Root Cause

Trong `AboutPanel.tsx`, active `MenuItem` bị override màu nền qua custom `className`:

```tsx
// Before — sai
className={mergeClassnames(
  currentSection === section.type && 'bg-red-60 border-none', // ← debug color commit nhầm
  section.type === 'moderations' && 'border border-red-90',
)}
```

`bg-red-60` (#FF2559 — đỏ chói) được append vào `mergeClassnames` sau cùng nên override luôn `bg-primary-90` mà `MenuItem` tự apply khi `isSelected=true`. Kết quả: active item hiển thị đỏ thay vì xanh nhạt đúng design.

## Changes

**`AboutPanel.tsx`**
- Xóa `currentSection === section.type && 'bg-red-60 border-none'` khỏi `className`
- Giữ nguyên `section.type === 'moderations' && 'border border-red-90'` vì đây là intentional warning indicator cho moderation section
- `MenuItem` đã có `isSelected={currentSection === section.type}` → tự apply `bg-primary-90 text-primary-60` đúng design

## Screenshots
<img width="951" height="668" alt="Screenshot 2026-05-12 at 22 30 31" src="https://github.com/user-attachments/assets/89d8be86-0ebd-4c3a-891b-d4f9f4c7eff0" />
---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)