### PR TITLE
feat: hide locale switcher and set English as default locale

### DIFF
--- a/src/app/[locale]/admin/(auth)/users/[id]/page.tsx
+++ b/src/app/[locale]/admin/(auth)/users/[id]/page.tsx
@@ -15,7 +15,7 @@ import Popover from '@/components/core/popover/Popover';
 import { mergeClassnames } from '@/components/core/private/utils';
 import { pushSuccess } from '@/components/CustomToastifyContainer';
 import { Spinner } from '@/components/loadingState/Spinner';
-import { LocaleSwitcher } from '@/components/LocaleSwitcher';
+// import { LocaleSwitcher } from '@/components/LocaleSwitcher';
 import { ProfileCover } from '@/components/ProfileCover';
 import { ActionOnUserModal } from '@/layouts/admin/ActionOnUserModal';
 import AboutPanel from '@/layouts/profile/AboutPanel';
@@ -206,7 +206,7 @@ export default function Index() {
                           </MenuItem>
                         ),
                       )}
-                      <LocaleSwitcher className="lg:hidden" />
+                      {/* <LocaleSwitcher className="lg:hidden" /> */}
                     </div>
                   )}
                 </Popover.Panel>

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -5,7 +5,7 @@ import { getSession } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useState } from 'react';
 
-import { LocaleSwitcher } from '@/components/LocaleSwitcher';
+// import { LocaleSwitcher } from '@/components/LocaleSwitcher';
 import { Logo } from '@/components/Logo';
 import { mergeClassnames } from '@/components/core/private/utils';
 
@@ -47,7 +47,7 @@ const Header = () => {
           </Link>
         </div>
         <div className="relative flex items-center justify-end gap-6">
-          <LocaleSwitcher className="shrink" />
+          {/* <LocaleSwitcher className="shrink" /> */}
           <Link
             href="#newsletter"
             className={mergeClassnames(

--- a/src/layouts/admin/Header.tsx
+++ b/src/layouts/admin/Header.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 
 import { HeaderIconButtonWithBadge } from '../webapp/Header';
 
-import { LocaleSwitcher } from '@/components/LocaleSwitcher';
+// import { LocaleSwitcher } from '@/components/LocaleSwitcher';
 import { Logo } from '@/components/Logo';
 import AdvancedSearch from '@/layouts/webapp/AdvancedSearch';
 import AvatarPopover from '@/layouts/webapp/AvatarPopover';
@@ -104,7 +104,7 @@ const Header = () => {
                 <div className="ml-2">
                   <AvatarPopover />
                 </div>
-                <LocaleSwitcher className="shrink" />
+                {/* <LocaleSwitcher className="shrink" /> */}
               </div>
             )}
       </header>

--- a/src/layouts/webapp/AvatarPopover.tsx
+++ b/src/layouts/webapp/AvatarPopover.tsx
@@ -17,7 +17,7 @@ import React, { useMemo } from 'react';
 import Avatar from '@/components/core/avatar/Avatar';
 import MenuItem from '@/components/core/menuItem/MenuItem';
 import Popover from '@/components/core/popover/Popover';
-import { LocaleSwitcher } from '@/components/LocaleSwitcher';
+// import { LocaleSwitcher } from '@/components/LocaleSwitcher';
 import { useAppSelector } from '@/libs/hooks';
 import { Role } from '@/types/common';
 import { Env } from '@/libs/Env.mjs';
@@ -141,7 +141,7 @@ export default function AvatarPopover() {
                     </MenuItem>
                   ),
             )}
-            <LocaleSwitcher className="lg:hidden" />
+            {/* <LocaleSwitcher className="lg:hidden" /> */}
           </div>
         )}
       </Popover.Panel>

--- a/src/layouts/webapp/Header.tsx
+++ b/src/layouts/webapp/Header.tsx
@@ -13,7 +13,7 @@ import React, { useCallback, useMemo } from 'react';
 import Button from '@/components/core/button/Button';
 import Popover from '@/components/core/popover/Popover';
 import { mergeClassnames } from '@/components/core/private/utils';
-import { LocaleSwitcher } from '@/components/LocaleSwitcher';
+// import { LocaleSwitcher } from '@/components/LocaleSwitcher';
 import { Logo } from '@/components/Logo';
 import AdvancedSearch from '@/layouts/webapp/AdvancedSearch';
 import AvatarPopover from '@/layouts/webapp/AvatarPopover';
@@ -271,7 +271,7 @@ const Header = () => {
                 <div className="ml-2">
                   <AvatarPopover />
                 </div>
-                <LocaleSwitcher className="shrink" />
+                {/* <LocaleSwitcher className="shrink" /> */}
               </div>
             )}
       </header>

--- a/src/utils/AppConfig.ts
+++ b/src/utils/AppConfig.ts
@@ -8,7 +8,7 @@ const localePrefix: LocalePrefixMode = 'as-needed';
 export const AppConfig = {
   name: 'Human Library',
   locales: ['en', 'vi'],
-  defaultLocale: 'vi',
+  defaultLocale: 'en',
   localePrefix,
   api: {
     version: Env.NEXT_PUBLIC_REACT_APP_BACKEND_VERSION,


### PR DESCRIPTION
This temporarily removes the language switcher from UI due to Vietnamese wording display issues, while defaulting new users to English.

## What this PR does
- [x]  Comment out LocaleSwitcher component in all headers and popovers (landing page, webapp, admin, avatar popover, user profile page)
- [x] Change defaultLocale from 'vi' to 'en' in AppConfig.ts

## Related Issue
Fixes https://github.com/hulib-engineering/hulib/issues/445

## Screenshots
<img width="1912" height="1028" alt="image" src="https://github.com/user-attachments/assets/c8cc13e0-aea6-4f0d-b478-db0db3edf5a4" />

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)
