### PR TITLE
fix: improve userInfo handling in AvatarPopover and reset state on lo…

### DIFF
--- a/src/layouts/webapp/AvatarPopover.tsx
+++ b/src/layouts/webapp/AvatarPopover.tsx
@@ -26,7 +26,9 @@ export default function AvatarPopover() {
   const currentLocale = useLocale();
   const t = useTranslations('HeaderWebApp');
 
-  const { id, role } = useAppSelector(state => state.auth.userInfo);
+  const userInfo = useAppSelector(state => state.auth.userInfo);
+  const id = userInfo?.id;
+  const role = userInfo?.role;
   const avatarUrl = useAppSelector(state => state.auth.avatarUrl);
 
   const AvatarPopoverMenuItems = useMemo(

--- a/src/libs/store/authentication/index.ts
+++ b/src/libs/store/authentication/index.ts
@@ -25,13 +25,16 @@ const slice = createSlice({
       const accessToken = action.payload;
       localStorage.setItem('access_token', accessToken);
     },
-    logout: () => {
+    logout: (state) => {
       localStorage.clear();
       Cookies.remove('refresh_token');
       Cookies.remove('currentUser');
       Cookies.set('NEXT_LOCALE', 'vi');
       Cookies.remove('defaultLocale');
       Cookies.remove('locales');
+      state.userInfo = {} as SliceState['userInfo'];
+      state.avatarUrl = '';
+      state.avatarId = '';
       // Sign out and redirect to the login page
       signOut({ callbackUrl: '/auth/login' });
     },


### PR DESCRIPTION
## What this PR does
- [x] Fix my schedule page sometimes crashes (Root cause: The TypeError Cannot destructure property 'auth' of 'e' as it is null originates from AvatarPopover.tsx In the production bundle (react-redux v9), useSelector wraps the selector call inside a useMemo. When the SWC compiler optimizes the selector state => state.auth.userInfo, it can transform repeated property accesses into destructuring form (const { auth } = state). If state or userInfo is null at render time (e.g., during a logout transition or an auth error re-render cycle), this destructuring crashes.)

## Related Issue
https://github.com/hulib-engineering/hulib/issues/462

## Screenshots

---

**Checklist**
- [x] Code builds without errors
- [ ] Changes are tested locally
- [x] Related issue is linked (if applicable)
