### PR TITLE
feat(admin): add per-story cover backfill page for legacy presets

### DIFF
--- a/src/app/[locale]/admin/(auth)/stories/[id]/approval/page.tsx
+++ b/src/app/[locale]/admin/(auth)/stories/[id]/approval/page.tsx
@@ -99,6 +99,17 @@ export default function Index() {
         abstract={data?.abstract || ''}
       />
 
+      <div className="flex items-center justify-end gap-3">
+        <Button
+          variant="outline"
+          size="lg"
+          className="w-60"
+          onClick={() => router.push(`/admin/stories/${id}/cover`)}
+        >
+          Regenerate cover
+        </Button>
+      </div>
+
       {/* Approve/Decline buttons at the bottom */}
       <div className="flex items-center justify-end gap-3">
         <Button

--- a/src/app/[locale]/admin/(auth)/stories/[id]/cover/page.tsx
+++ b/src/app/[locale]/admin/(auth)/stories/[id]/cover/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { ArrowLeft } from '@phosphor-icons/react';
+import { useParams, useRouter } from 'next/navigation';
+
+import Button from '@/components/core/button/Button';
+import { StoryDetailSkeleton } from '@/components/loadingState/Skeletons';
+import { AdminStoryCoverForm } from '@/features/stories/components/AdminStoryCoverForm';
+import { useGetStoryDetailQuery } from '@/libs/services/modules/stories';
+
+export default function AdminStoryCoverPage() {
+  const { id } = useParams();
+  const router = useRouter();
+  const storyId = Number(id);
+
+  const { data: story, isLoading, refetch } = useGetStoryDetailQuery(storyId);
+
+  if (isLoading) {
+    return <StoryDetailSkeleton />;
+  }
+
+  if (!story) {
+    return null;
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-6 pb-8 pt-6">
+      <Button
+        variant="ghost"
+        size="lg"
+        iconLeft={<ArrowLeft />}
+        className="w-fit text-black"
+        onClick={() => router.push(`/admin/stories/${storyId}/approval`)}
+      >
+        Back to story approval
+      </Button>
+
+      <div className="flex flex-col gap-2">
+        <h1 className="text-2xl font-medium text-neutral-10">Regenerate story cover</h1>
+        <p className="text-sm text-neutral-40">
+          Pick a preset style and confirm the title shown on the cover. Author name comes from the huber profile.
+          Saving uploads a new PNG and replaces the story cover in the database.
+        </p>
+      </div>
+
+      <div className="rounded-2xl bg-white p-6 shadow-sm">
+        <AdminStoryCoverForm
+          story={story}
+          onSaved={() => refetch()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/stories/components/AdminStoryCoverForm.tsx
+++ b/src/features/stories/components/AdminStoryCoverForm.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useCallback, useState } from 'react';
+
+import Button from '@/components/core/button/Button';
+import TextArea from '@/components/core/textArea/TextArea';
+import TextInput from '@/components/core/textInput-v1/TextInput';
+import { pushError, pushSuccess } from '@/components/CustomToastifyContainer';
+import {
+  AdminStoryCoverPreview,
+  AdminStoryCoverThumbnail,
+} from '@/features/stories/components/AdminStoryCoverPreview';
+import {
+  COVER_PRESET_ASSETS,
+  COVER_PREVIEW_ELEMENT_ID,
+  type CoverPresetAsset,
+} from '@/features/stories/constants';
+import type { CoverCustomization } from '@/features/stories/types';
+import {
+  getAdminPresetCustomization,
+  isPresetCoverAsset,
+  isRasterizedStoryCover,
+} from '@/features/stories/utils';
+import { saveStoryCoverFile } from '@/features/stories/utils/saveStoryCover';
+import { useUploadMutation } from '@/libs/services/modules/files';
+import { useUpdateStoryMutation } from '@/libs/services/modules/stories';
+import type { Story } from '@/libs/services/modules/stories/storiesType';
+
+const inferPresetAsset = (coverPath?: string): CoverPresetAsset => {
+  if (coverPath?.includes('story_background_red')) {
+    return COVER_PRESET_ASSETS[1]!;
+  }
+  if (coverPath?.includes('story_background_blue')) {
+    return COVER_PRESET_ASSETS[2]!;
+  }
+  return COVER_PRESET_ASSETS[0]!;
+};
+
+type AdminStoryCoverFormProps = {
+  story: Story;
+  onSaved?: () => void;
+};
+
+export const AdminStoryCoverForm = ({ story, onSaved }: AdminStoryCoverFormProps) => {
+  const t = useTranslations('Common');
+  const [uploadCover] = useUploadMutation();
+  const [updateStory, { isLoading: isUpdating }] = useUpdateStoryMutation();
+
+  const initialPreset = inferPresetAsset(story.cover?.path);
+  const [selectedPreset, setSelectedPreset] = useState<CoverPresetAsset>(initialPreset);
+  const [customization, setCustomization] = useState<CoverCustomization>(
+    () => getAdminPresetCustomization(initialPreset),
+  );
+  const [coverTitle, setCoverTitle] = useState(story.title);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const authorName = story.humanBook?.fullName ?? '';
+  const currentCoverPath = story.cover?.path?.trim() ?? '';
+  const needsBackfill = !isRasterizedStoryCover(currentCoverPath);
+  const isLegacyPresetInDb = isPresetCoverAsset(currentCoverPath);
+
+  const handleSelectPreset = useCallback((preset: CoverPresetAsset) => {
+    setSelectedPreset(preset);
+    setCustomization(getAdminPresetCustomization(preset));
+  }, []);
+
+  const handleSave = async () => {
+    const trimmedTitle = coverTitle.trim();
+    if (!trimmedTitle) {
+      pushError(t('error_contact_admin'));
+      return;
+    }
+    if (!authorName.trim()) {
+      pushError('Author name is missing on this story.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const fileId = await saveStoryCoverFile(
+        uploadCover,
+        `story-${story.id}-cover`,
+        COVER_PREVIEW_ELEMENT_ID,
+      );
+      if (!fileId) {
+        pushError(t('error_contact_admin'));
+        return;
+      }
+
+      await updateStory({
+        id: story.id,
+        cover: { id: fileId },
+      }).unwrap();
+
+      pushSuccess('Cover saved. Title and author are now baked into the image.');
+      onSaved?.();
+    } catch (err) {
+      console.error('Admin cover save failed', err);
+      const apiMessage = (err as { data?: { errors?: { file?: string } } })?.data?.errors?.file;
+      pushError(
+        apiMessage === 'cantUploadFileType'
+          ? 'Cover upload failed: file must be a PNG image.'
+          : t('error_contact_admin'),
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const isBusy = isSaving || isUpdating;
+
+  return (
+    <div className="flex flex-col gap-6">
+      {needsBackfill && (
+        <p className="bg-amber-98 text-amber-30 rounded-lg px-4 py-3 text-sm">
+          This story still uses a preset background URL without baked title/author text.
+          Save a new cover image before publishing.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <div className="flex flex-1 flex-col gap-4">
+          <TextInput
+            type="text"
+            label={(
+              <p className="text-sm leading-4 text-neutral-10">Title on cover</p>
+            )}
+            value={coverTitle}
+            onChange={e => setCoverTitle(e.target.value)}
+            maxLength={32}
+          />
+          <TextInput
+            type="text"
+            label={(
+              <p className="text-sm leading-4 text-neutral-10">Author on cover</p>
+            )}
+            value={authorName}
+            disabled
+          />
+          <div>
+            <p className="mb-2 text-sm leading-4 text-neutral-10">Story description</p>
+            <TextArea
+              value={story.abstract}
+              readOnly
+              rows={6}
+              size="sm"
+            />
+          </div>
+
+          <div>
+            <p className="mb-2 text-sm font-medium text-neutral-10">Cover style</p>
+            <div className="flex flex-wrap gap-3">
+              {COVER_PRESET_ASSETS.map((preset, index) => (
+                <div key={preset} className="flex shrink-0 flex-col items-center gap-1">
+                  <AdminStoryCoverThumbnail
+                    storyTitle={coverTitle.trim() || t('placeholder_title')}
+                    authorName={authorName}
+                    coverImgSrc={preset}
+                    customization={getAdminPresetCustomization(preset)}
+                    selected={selectedPreset === preset}
+                    onSelect={() => handleSelectPreset(preset)}
+                  />
+                  <span className="text-xs text-neutral-40">{`${t('style')} ${index + 1}`}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center gap-4 lg:min-w-[200px]">
+          <div className="text-center">
+            <p className="text-sm font-medium text-neutral-10">New cover (preview)</p>
+            <p className="text-xs text-neutral-40">
+              Title and author are drawn on the preset — this is what Save will upload.
+            </p>
+          </div>
+          <AdminStoryCoverPreview
+            storyTitle={coverTitle.trim() || t('placeholder_title')}
+            authorName={authorName}
+            coverImgSrc={selectedPreset}
+            customization={customization}
+          />
+          <div className="w-full border-t border-neutral-90 pt-4">
+            <p className="mb-1 text-sm font-medium text-neutral-10">Current cover in database</p>
+            <p className="mb-2 text-xs text-neutral-40">
+              {isLegacyPresetInDb
+                ? 'Stored file is the preset PNG only — no title or author in the image (prod showed text via code overlay).'
+                : needsBackfill
+                  ? 'No rasterized cover file yet.'
+                  : 'Rasterized PNG already stored (title and author are in the file).'}
+            </p>
+            {currentCoverPath ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={currentCoverPath}
+                alt="Current cover in database"
+                width={184}
+                height={259}
+                className="mx-auto shrink-0 rounded-[4px] object-fill"
+              />
+            ) : (
+              <p className="text-center text-xs text-neutral-40">No cover path on this story.</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          size="lg"
+          className="min-w-[200px]"
+          animation={isBusy ? 'progress' : undefined}
+          disabled={isBusy}
+          onClick={handleSave}
+        >
+          Save cover to database
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/stories/components/AdminStoryCoverPreview.tsx
+++ b/src/features/stories/components/AdminStoryCoverPreview.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { mergeClassnames } from '@/components/core/private/utils';
+import { CustomCoverBuilder } from '@/features/stories/components/CustomCoverBuilder';
+import { COVER_PREVIEW_ELEMENT_ID, COVER_SIZE_TOKENS } from '@/features/stories/constants';
+import type { CoverCustomization } from '@/features/stories/types';
+
+const EXPORT = COVER_SIZE_TOKENS.desktop;
+
+type AdminStoryCoverPreviewProps = {
+  storyTitle: string;
+  authorName: string;
+  coverImgSrc: string;
+  customization: CoverCustomization;
+};
+
+/**
+ * Admin backfill: fixed 184×259 shell + builder (preset once, title/author on top).
+ * Do not stack a second img under the builder — that doubled the preset and looked blurry.
+ */
+export const AdminStoryCoverPreview = ({
+  storyTitle,
+  authorName,
+  coverImgSrc,
+  customization,
+}: AdminStoryCoverPreviewProps) => (
+  <div
+    id={COVER_PREVIEW_ELEMENT_ID}
+    className="relative shrink-0 overflow-hidden rounded-[4px]"
+    style={{ width: EXPORT.width, height: EXPORT.height }}
+  >
+    <CustomCoverBuilder
+      useExportDimensions
+      storyTitle={storyTitle}
+      authorName={authorName}
+      coverImgSrc={coverImgSrc}
+      customization={customization}
+      active
+      className="size-full"
+    />
+  </div>
+);
+
+type AdminStoryCoverThumbnailProps = AdminStoryCoverPreviewProps & {
+  selected: boolean;
+  onSelect: () => void;
+};
+
+export const AdminStoryCoverThumbnail = ({
+  selected,
+  onSelect,
+  ...coverProps
+}: AdminStoryCoverThumbnailProps) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    className={mergeClassnames(
+      'relative shrink-0 overflow-hidden rounded-[4px] outline-none ring-2 ring-offset-2 transition-shadow',
+      selected ? 'ring-primary-50' : 'ring-transparent',
+      'focus-visible:ring-primary-50',
+    )}
+    style={{ width: EXPORT.width, height: EXPORT.height }}
+    aria-pressed={selected}
+  >
+    <CustomCoverBuilder
+      useExportDimensions
+      storyTitle={coverProps.storyTitle}
+      authorName={coverProps.authorName}
+      coverImgSrc={coverProps.coverImgSrc}
+      customization={coverProps.customization}
+      active
+      className="size-full"
+    />
+  </button>
+);

--- a/src/features/stories/components/CustomCoverBuilder.tsx
+++ b/src/features/stories/components/CustomCoverBuilder.tsx
@@ -31,6 +31,8 @@ export type ICustomCoverBuilderProps = {
   coverImgSrc?: string;
   onClick?: () => void;
   previewId?: string;
+  /** Desktop export size (184×259) while keeping normal visible chrome — use with `previewId` on admin save preview. */
+  useExportDimensions?: boolean;
   customization?: CoverCustomization;
   className?: string;
 };
@@ -64,13 +66,15 @@ export function CustomCoverBuilder({
   coverImgSrc = '',
   onClick,
   previewId,
+  useExportDimensions = false,
   customization,
   className,
 }: ICustomCoverBuilderProps) {
   const isMobile = useMobile();
 
   const isExportTarget = previewId === COVER_EXPORT_ELEMENT_ID;
-  const size = isExportTarget ? COVER_EXPORT_SIZE : (isMobile ? 'mobile' : 'desktop');
+  const useDesktopExportLayout = isExportTarget || useExportDimensions;
+  const size = useDesktopExportLayout ? COVER_EXPORT_SIZE : (isMobile ? 'mobile' : 'desktop');
 
   const tokens = COVER_SIZE_TOKENS[size];
   const desktopTokens = COVER_SIZE_TOKENS.desktop;
@@ -271,23 +275,19 @@ export function CustomCoverBuilder({
 
   const ChromeWrapper = useBakedPresetChrome ? CoverBakedPreset : CoverExport;
   const chromeProps = useBakedPresetChrome
-    ? { fixedDesktopSize: isExportTarget, id: isExportTarget ? previewId : undefined }
-    : { fixedDesktopSize: isExportTarget, paperColor, id: isExportTarget ? previewId : undefined };
+    ? { fixedDesktopSize: useDesktopExportLayout, id: previewId }
+    : { fixedDesktopSize: useDesktopExportLayout, paperColor, id: previewId };
 
   return (
     <ChromeWrapper
       {...chromeProps}
       {...(isExportTarget ? {} : interactiveProps)}
-      className={
-        isExportTarget
-          ? undefined
-          : mergeClassnames(
-              'outline-none focus:outline-none',
-              !active && 'grayscale',
-              onClick && 'cursor-pointer',
-              className,
-            )
-      }
+      className={mergeClassnames(
+        'shrink-0 outline-none focus:outline-none',
+        !active && 'grayscale',
+        onClick && 'cursor-pointer',
+        className,
+      )}
     >
       {coverContent}
     </ChromeWrapper>

--- a/src/features/stories/utils/coverPreset.ts
+++ b/src/features/stories/utils/coverPreset.ts
@@ -99,3 +99,9 @@ export const getDefaultCustomization = (backgroundSrc: string): CoverCustomizati
     authorColor,
   };
 };
+
+/** Admin backfill: preset PNG as-is + title/author only (no 35% editing swatch wash). */
+export const getAdminPresetCustomization = (backgroundSrc: string): CoverCustomization => {
+  const base = getDefaultCustomization(backgroundSrc);
+  return { ...base, backgroundColor: undefined };
+};

--- a/src/features/stories/utils/index.ts
+++ b/src/features/stories/utils/index.ts
@@ -1,6 +1,7 @@
 export {
   getCoverFontClassName,
   getDefaultCustomization,
+  getAdminPresetCustomization,
   getPresetPlainBackgroundColor,
   getPresetStyle,
   hasBakedPresetChrome,
@@ -11,3 +12,4 @@ export {
 export { rasterizeCoverElement } from './rasterizeCover';
 export { renderHighlightedText } from './renderHighlightedText';
 export { uploadCoverBlob } from './uploadCoverBlob';
+export { saveStoryCoverFile } from './saveStoryCover';

--- a/src/features/stories/utils/saveStoryCover.ts
+++ b/src/features/stories/utils/saveStoryCover.ts
@@ -1,0 +1,16 @@
+import { COVER_EXPORT_ELEMENT_ID } from '@/features/stories/constants';
+import { rasterizeCoverElement } from '@/features/stories/utils/rasterizeCover';
+import { uploadCoverBlob } from '@/features/stories/utils/uploadCoverBlob';
+import type { useUploadMutation } from '@/libs/services/modules/files';
+
+type UploadCoverMutation = ReturnType<typeof useUploadMutation>[0];
+
+export async function saveStoryCoverFile(
+  uploadCover: UploadCoverMutation,
+  fileNameBase: string,
+  elementId: string = COVER_EXPORT_ELEMENT_ID,
+): Promise<string | undefined> {
+  const blob = await rasterizeCoverElement(elementId);
+  const fileName = `${fileNameBase}-${Date.now()}.png`;
+  return uploadCoverBlob(blob, fileName, uploadCover);
+}


### PR DESCRIPTION
Admin can pick a preset, edit the cover title, preview WYSIWYG at export size, and save a rasterized PNG to replace preset-only cover.path URLs before shipping flat Cover display.

## What this PR does
- [x] Add admin modifying old covers on production

## Related Issue
Related to https://github.com/hulib-engineering/hulib/issues/473

## Screenshots
<img width="826" height="400" alt="image" src="https://github.com/user-attachments/assets/8933fe70-f541-4aeb-ba00-37d1555de8cb" />

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)
