### PR TITLE
feat: display topic chips with their stored color across the app

### DIFF
--- a/src/app/[locale]/(auth)/explore-story/[id]/page.tsx
+++ b/src/app/[locale]/(auth)/explore-story/[id]/page.tsx
@@ -8,13 +8,15 @@ import { useState } from 'react';
 
 import Avatar from '@/components/core/avatar/Avatar';
 import Button from '@/components/core/button/Button';
+import { Chip } from '@/components/core/chip/Chip';
+import { mergeClassnames } from '@/components/core/private/utils';
 import { IndexStoryListSectionLayout } from '@/components/home/IndexStoryListCommonLayout';
 import { StoryDetailSkeleton } from '@/components/loadingState/Skeletons';
 import { Cover } from '@/features/stories/components/Cover';
 import { DEFAULT_STORY_COVER_ASSET } from '@/features/stories/constants';
 import { DetailedStory } from '@/components/stories/DetailedStory';
 import StoryReviewsWithOverview from '@/layouts/stories/StoryReviewsWithOverview';
-import { TopicChip } from '@/layouts/webapp/ChipFilter';
+import { getTopicBadgeClasses } from '@/features/admin/utils/getTopicBadgeClasses';
 import {
   useGetReviewsOverviewQuery,
   useGetSimilarStoriesQuery,
@@ -114,15 +116,19 @@ export default function Index() {
                     </p>
                   </div>
                 </div>
-                <div className="hidden w-auto gap-2 overflow-x-auto scroll-smooth py-1 lg:flex">
+                <div className="scrollbar-none hidden w-auto gap-2 overflow-x-auto scroll-smooth py-1 lg:flex">
                   {data?.topics.map((topic: Topic) => (
-                    <TopicChip
-                      className="border-none bg-blue-90 text-primary-50"
+                    <Chip
                       key={topic.id}
-                      isActive
+                      as="span"
+                      className={mergeClassnames(
+                        'h-8 min-w-0 shrink-0 overflow-visible whitespace-nowrap rounded-2xl border py-1 px-2 lg:py-2',
+                        'text-xs font-medium leading-[14px] lg:text-sm lg:font-normal lg:leading-4',
+                        getTopicBadgeClasses(topic.color),
+                      )}
                     >
                       {topic.name}
-                    </TopicChip>
+                    </Chip>
                   ))}
                 </div>
               </div>

--- a/src/app/[locale]/(auth)/explore-story/[id]/preview/page.tsx
+++ b/src/app/[locale]/(auth)/explore-story/[id]/preview/page.tsx
@@ -9,6 +9,7 @@ import { useState } from 'react';
 
 import Button from '@/components/core/button/Button';
 import { Chip } from '@/components/core/chip/Chip';
+import { mergeClassnames } from '@/components/core/private/utils';
 import { pushError } from '@/components/CustomToastifyContainer';
 import { StoryDetailSkeleton } from '@/components/loadingState/Skeletons';
 import Label from '@/components/Label';
@@ -16,6 +17,7 @@ import Modal from '@/components/Modal';
 import { Cover } from '@/features/stories/components/Cover';
 import { DEFAULT_STORY_COVER_ASSET } from '@/features/stories/constants';
 import { DetailedStory } from '@/components/stories/DetailedStory';
+import { getTopicBadgeClasses } from '@/features/admin/utils/getTopicBadgeClasses';
 import StoryForm from '@/features/stories/components/StoryForm';
 import { useAppSelector } from '@/libs/hooks';
 import {
@@ -111,9 +113,11 @@ export default function Index() {
                   <div className="flex w-full snap-x snap-mandatory gap-2 overflow-x-auto scroll-smooth">
                     {(relatedTopics ?? []).map((topic: Topic) => (
                       <Chip
-                        className="h-fit w-full snap-start overflow-visible rounded-2xl bg-blue-90 p-2 text-xs leading-[14px] text-primary-50"
                         key={topic.id}
-                        disabled
+                        className={mergeClassnames(
+                          'h-fit snap-start overflow-visible rounded-2xl border p-2 text-xs leading-[14px]',
+                          getTopicBadgeClasses(topic.color),
+                        )}
                       >
                         {topic.name}
                       </Chip>

--- a/src/app/[locale]/admin/(auth)/stories/[id]/approval/page.tsx
+++ b/src/app/[locale]/admin/(auth)/stories/[id]/approval/page.tsx
@@ -14,8 +14,10 @@ import {
 } from '@/libs/services/modules/stories';
 import type { Topic } from '@/libs/services/modules/user/userType';
 import Avatar from '@/components/core/avatar/Avatar';
-import { TopicChip } from '@/layouts/webapp/ChipFilter';
+import { Chip } from '@/components/core/chip/Chip';
+import { mergeClassnames } from '@/components/core/private/utils';
 import { Cover } from '@/features/stories/components/Cover';
+import { getTopicBadgeClasses } from '@/features/admin/utils/getTopicBadgeClasses';
 import { DEFAULT_STORY_COVER_ASSET } from '@/features/stories/constants';
 
 export default function Index() {
@@ -80,13 +82,18 @@ export default function Index() {
             </div>
             <div className="flex gap-2 overflow-x-auto scroll-smooth py-1">
               {data?.topics.map((topic: Topic) => (
-                <TopicChip
-                  className="border-none bg-blue-90 text-primary-50"
+                <Chip
                   key={topic.id}
-                  isActive
+                  as="span"
+                  className={mergeClassnames(
+                    'h-8 min-w-0 shrink-0 overflow-visible whitespace-nowrap rounded-2xl py-1 px-2 lg:py-2',
+                    'text-xs font-medium leading-[14px] lg:text-sm lg:font-normal lg:leading-4',
+                    'border',
+                    getTopicBadgeClasses(topic.color),
+                  )}
                 >
                   {topic.name}
-                </TopicChip>
+                </Chip>
               ))}
             </div>
           </div>

--- a/src/components/hubers/HuberCard.tsx
+++ b/src/components/hubers/HuberCard.tsx
@@ -5,12 +5,13 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import React, { useState } from 'react';
-
 import NiceAvatar, { genConfig } from 'react-nice-avatar';
 
 import Button from '@/components/core/button/Button';
 import IconButton from '@/components/core/iconButton/IconButton';
+import { mergeClassnames } from '@/components/core/private/utils';
 import { pushError, pushSuccess } from '@/components/CustomToastifyContainer';
+import { getTopicBadgeClasses } from '@/features/admin/utils/getTopicBadgeClasses';
 import type { Huber as THuber } from '@/libs/services/modules/huber/huberType';
 import { useAddHuberToMyFavoritesMutation, useRemoveHuberFromMyFavoritesMutation } from '@/libs/services/modules/user';
 
@@ -73,7 +74,9 @@ const HuberCard = (
               )}
           {props.awaiting && (
             <div className="absolute bottom-2 left-0 flex w-full items-center justify-center">
-              <span className="rounded-full bg-primary-60 px-4 py-2 text-xs leading-[14px] text-white">Waiting for approval</span>
+              <span className="rounded-full bg-primary-60 px-4 py-2 text-xs leading-[14px] text-white">
+                Waiting for approval
+              </span>
             </div>
           )}
         </div>
@@ -104,26 +107,8 @@ const HuberCard = (
           </div>
 
           {props.sharingTopics && (
-            <div className="absolute inset-0 flex h-fit items-center gap-2 p-4 lg:hidden lg:group-hover:flex">
-              {props.sharingTopics.map((topic, index) => {
-                const colors = [
-                  {
-                    backgroundColor: 'rgba(217, 249, 207, 1)',
-                    borderColor: 'rgba(178, 243, 159, 1)',
-                  },
-                  {
-                    backgroundColor: 'rgba(255, 228, 241, 1)',
-                    borderColor: 'rgba(255, 201, 227, 1)',
-                  },
-                  {
-                    backgroundColor: 'rgba(205, 221, 254, 1)',
-                    borderColor: 'rgba(132, 172, 252, 1)',
-                  },
-                ];
-
-                const colorIndex = index % colors.length;
-                const tagColor = colors[colorIndex];
-
+            <div className="absolute inset-0 flex h-fit flex-wrap gap-2 p-4 lg:hidden lg:group-hover:flex">
+              {props.sharingTopics.map((topic) => {
                 if (!props.humanBookTopic || props.humanBookTopic.length === 0) {
                   return null;
                 }
@@ -131,13 +116,12 @@ const HuberCard = (
                 return (
                   <span
                     key={topic.id}
-                    className="rounded-full px-3 py-2 text-xs font-medium leading-[14px] text-opacity-80"
-                    style={{
-                      backgroundColor: tagColor?.backgroundColor,
-                      border: `1px solid ${tagColor?.borderColor}`,
-                    }}
+                    className={mergeClassnames(
+                      'inline-flex max-w-full items-center overflow-hidden rounded-full border px-3 py-2 text-xs font-medium leading-[14px]',
+                      getTopicBadgeClasses(topic.color),
+                    )}
                   >
-                    {topic.name}
+                    <span className="truncate">{topic.name}</span>
                   </span>
                 );
               })}
@@ -179,7 +163,6 @@ const HuberCard = (
           {!props.awaiting ? (
             <>
               <Button
-                size="lg"
                 fullWidth
                 className="hidden lg:flex"
                 onClick={() => router.push(`${props.showAdminControls ? '/admin' : ''}/users/${props.id}`)}
@@ -191,7 +174,6 @@ const HuberCard = (
               </Button>
               <Button
                 variant="secondary"
-                size="lg"
                 fullWidth
                 className="lg:hidden"
                 onClick={() => router.push(`${props.showAdminControls ? '/admin' : ''}/users/${props.id}`)}
@@ -204,7 +186,6 @@ const HuberCard = (
             </>
           ) : (
             <Button
-              size="lg"
               fullWidth
               onClick={() => router.push(`/admin/users/${props.id}/approval`)}
             >

--- a/src/features/admin/utils/getTopicBadgeClasses.ts
+++ b/src/features/admin/utils/getTopicBadgeClasses.ts
@@ -10,14 +10,14 @@ type TopicColorToken =
 
 /** Per-token badge classes from Figma (node 14883:9384). */
 const TOPIC_BADGE_BY_TOKEN: Record<TopicColorToken, string> = {
-  primary: 'bg-primary-90 border-primary-80 text-primary-60',
-  blue: 'bg-blue-90 border-blue-80 text-blue-40',
-  lavender: 'bg-lavender-90 border-lavender-80 text-lavender-40',
-  green: 'bg-green-90 border-green-80 text-green-40',
-  yellow: 'bg-yellow-90 border-yellow-80 text-orange-50',
-  orange: 'bg-orange-90 border-orange-80 text-orange-50',
-  pink: 'bg-pink-90 border-pink-80 text-pink-40',
-  neutral: 'bg-neutral-98 border-neutral-90 text-neutral-30',
+  primary: 'bg-primary-90 border-primary-80 text-primary-60 hover:bg-primary-90 hover:text-primary-60',
+  blue: 'bg-blue-90 border-blue-80 text-blue-40 hover:bg-blue-90 hover:text-blue-40',
+  lavender: 'bg-lavender-90 border-lavender-80 text-lavender-40 hover:bg-lavender-90 hover:text-lavender-40',
+  green: 'bg-green-90 border-green-80 text-green-40 hover:bg-green-90 hover:text-green-40',
+  yellow: 'bg-yellow-90 border-yellow-80 text-orange-50 hover:bg-yellow-90 hover:text-orange-50',
+  orange: 'bg-orange-90 border-orange-80 text-orange-50 hover:bg-orange-90 hover:text-orange-50',
+  pink: 'bg-pink-90 border-pink-80 text-pink-40 hover:bg-pink-90 hover:text-pink-40',
+  neutral: 'bg-neutral-98 border-neutral-90 text-neutral-30 hover:bg-neutral-98 hover:text-neutral-30',
 };
 
 const TOPIC_COLOR_TOKENS = new Set<string>(Object.keys(TOPIC_BADGE_BY_TOKEN));

--- a/src/features/stories/components/StoryCard.tsx
+++ b/src/features/stories/components/StoryCard.tsx
@@ -5,15 +5,17 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import React, { useRef, useState } from 'react';
 
-import { pushError, pushSuccess } from '@/components/CustomToastifyContainer';
+import { DEFAULT_STORY_COVER_ASSET } from '../constants';
+
+import AnimatedCover from './AnimatedCover';
+import { Cover } from './Cover';
+
 import Avatar from '@/components/core/avatar/Avatar';
 import Button from '@/components/core/button/Button';
 import { Chip } from '@/components/core/chip/Chip';
 import { mergeClassnames } from '@/components/core/private/utils';
 import Modal from '@/components/Modal';
-import { Cover } from '@/features/stories/components/Cover';
-import AnimatedCover from '@/features/stories/components/AnimatedCover';
-import { DEFAULT_STORY_COVER_ASSET } from '@/features/stories/constants';
+import { getTopicBadgeClasses } from '@/features/admin/utils/getTopicBadgeClasses';
 import { renderHighlightedText } from '@/features/stories/utils/renderHighlightedText';
 import StoryForm from '@/features/stories/components/StoryForm';
 import { useDeleteStoryMutation } from '@/libs/services/modules/stories';
@@ -21,6 +23,7 @@ import type { Story as TStory } from '@/libs/services/modules/stories/storiesTyp
 import { StoryPublishStatus } from '@/libs/services/modules/stories/storiesType';
 import { useAddStoryToMyFavoritesMutation, useRemoveStoryFromMyFavoritesMutation } from '@/libs/services/modules/user';
 import { useMobile } from '@/libs/hooks';
+import { pushError, pushSuccess } from '@/components/CustomToastifyContainer';
 
 type IStoryCardProps = {
   data: TStory;
@@ -196,7 +199,11 @@ export const StoryCard = ({
                     {data.topics?.map(topic => (
                       <Chip
                         key={topic.id}
-                        className="h-full min-w-0 shrink-0 overflow-visible whitespace-nowrap rounded-2xl bg-primary-90 px-2 py-1 text-[10px] leading-3 text-primary-50"
+                        as="span"
+                        className={mergeClassnames(
+                          'h-full min-w-0 shrink-0 overflow-visible whitespace-nowrap rounded-2xl border px-2 py-1 text-[10px] leading-3',
+                          getTopicBadgeClasses(topic.color),
+                        )}
                       >
                         {topic.name}
                       </Chip>
@@ -276,7 +283,12 @@ export const StoryCard = ({
                 {data.topics?.map(topic => (
                   <Chip
                     key={topic.id}
-                    className="h-auto shrink-0 overflow-visible whitespace-nowrap rounded-2xl bg-primary-90 px-2 py-1 text-xs leading-[14px] text-primary-50 md:py-2"
+                    as="span"
+                    className={mergeClassnames(
+                      'h-auto shrink-0 overflow-visible whitespace-nowrap rounded-2xl px-2 py-1 text-xs leading-[14px] md:py-2',
+                      'border',
+                      getTopicBadgeClasses(topic.color),
+                    )}
                   >
                     {topic.name}
                   </Chip>

--- a/src/layouts/profile/OverviewSection.tsx
+++ b/src/layouts/profile/OverviewSection.tsx
@@ -12,6 +12,7 @@ import IconButton from '@/components/core/iconButton/IconButton';
 import { mergeClassnames } from '@/components/core/private/utils';
 import TextArea from '@/components/core/textArea/TextArea';
 import type { User } from '@/features/users/types';
+import { getTopicBadgeClasses } from '@/features/admin/utils/getTopicBadgeClasses';
 import { useUpdateProfileMutation } from '@/libs/services/modules/auth';
 import { Role } from '@/types/common';
 import { toLocaleDateString } from '@/utils/dateUtils';
@@ -75,7 +76,11 @@ const OverviewSection = ({ data, editable }: IOverviewSectionProps) => {
             {data?.humanBookTopic?.map(topic => (
               <Chip
                 key={topic?.topicId}
-                className="h-full rounded-2xl border border-primary-80 bg-primary-90 p-2 text-xs font-medium leading-[14px] text-primary-60"
+                as="span"
+                className={mergeClassnames(
+                  'h-full rounded-2xl border p-2 text-xs font-medium leading-[14px]',
+                  getTopicBadgeClasses(topic?.topic?.color),
+                )}
               >
                 {topic?.topic?.name}
               </Chip>

--- a/src/libs/services/modules/user/userType.ts
+++ b/src/libs/services/modules/user/userType.ts
@@ -1,6 +1,7 @@
 export type Topic = {
   id: number;
   name: string;
+  color?: string;
 };
 
 export type GetUsersParams = {


### PR DESCRIPTION
## What this PR does
- [x] Apply getTopicBadgeClasses() to topic chips on explore-story detail, preview, admin approval, StoryCard, HuberCard, and profile OverviewSection
- [x]  Fix HuberCard topic badge overflow leaking outside card via max-w-full/truncate

## Related Issue
Closes https://github.com/hulib-engineering/hulib/issues/484

## Screenshots
<img width="1589" height="1457" alt="image" src="https://github.com/user-attachments/assets/388d20d9-7843-4bcb-90d4-756eab4393fe" />

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)
