### PR TITLE
feat: optimistic send, viewport-based read, and real-time receive in …

### DIFF
--- a/src/layouts/HumanBookBanner.tsx
+++ b/src/layouts/HumanBookBanner.tsx
@@ -41,7 +41,7 @@ const HumanBookBanner = () => {
   }, [isUserLoggedInButTokenHasExpired]);
 
   return (
-    // eslint-disable-next-line tailwindcss/no-contradicting-classname
+
     <div className="relative animate-flashing bg-[linear-gradient(120deg,_#0442bf_30%,_#0858fa80_38%,_#0858fa80_40%,_#0442bf_48%)] bg-[length:200%_100%] bg-right-top">
       <div
         className={mergeClassnames(

--- a/src/layouts/webapp/Messages/ChatDetail.tsx
+++ b/src/layouts/webapp/Messages/ChatDetail.tsx
@@ -9,7 +9,7 @@ import {
   isYesterday,
 } from 'date-fns';
 import Image from 'next/image';
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 
 import Avatar from '@/components/core/avatar/Avatar';
 import Button from '@/components/core/button/Button';
@@ -70,17 +70,20 @@ export function groupMessagesByTime(
   return result;
 }
 
-export const MessageItem = ({
+export const MessageItem = React.memo(({
   type,
   participantAvatarUrl,
   markedAsRead = false,
+  id,
   children,
 }: WithChildren<{
   type: 'sent' | 'received';
   participantAvatarUrl?: string;
   markedAsRead?: boolean;
+  id?: string;
 }>) => (
   <div
+    id={id}
     className={mergeClassnames(
       'flex flex-col gap-1 px-5 py-2',
       markedAsRead && 'items-end',
@@ -107,7 +110,7 @@ export const MessageItem = ({
       <Image
         className="size-5 rounded-full"
         src={participantAvatarUrl ?? '/assets/images/ava-placeholder.png'}
-        alt="Sender Avatar"
+        alt="Read by"
         width={20}
         height={20}
         objectFit="cover"
@@ -118,12 +121,14 @@ export const MessageItem = ({
       />
     )}
   </div>
-);
+));
+MessageItem.displayName = 'MessageItem';
 
 export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixed?: boolean; onBack?: () => void }) {
   const currentOpeningChat = useAppSelector(
     state => state.messenger.currentChatDetail,
   );
+  const userInfo = useAppSelector(state => state.auth.userInfo);
 
   const dispatch = useAppDispatch();
 
@@ -138,7 +143,42 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
     skip: !currentOpeningChat,
   });
 
-  const { emit, isConnected } = useSocket({ namespace: 'chat', listeners: {} });
+  const handleReceiveMessage = useCallback(
+    (payload: { id: number; from: number; to: number; msg: string; time: number }) => {
+      if (!currentOpeningChat || payload.from !== Number(currentOpeningChat.id)) {
+        return;
+      }
+      dispatch(
+        chatApi.util.updateQueryData(
+          'getConversation',
+          Number(currentOpeningChat.id),
+          (draft) => {
+            if (draft.some(m => m.id === String(payload.id))) {
+              return;
+            }
+            draft.unshift({
+              id: String(payload.id),
+              from: payload.from,
+              to: payload.to,
+              msg: payload.msg,
+              chatType: 'txt',
+              time: new Date(payload.time).toISOString(),
+              direction: 'received' as const,
+              isRead: false,
+            });
+          },
+        ),
+      );
+    },
+    [currentOpeningChat, dispatch],
+  );
+
+  const { emit, isConnected } = useSocket({
+    namespace: 'chat',
+    listeners: {
+      receive: handleReceiveMessage,
+    },
+  });
 
   const messageContainerRef = useRef<HTMLDivElement>(null);
 
@@ -148,28 +188,29 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
     }
   }, [data]);
   useEffect(() => {
-    const container = messageContainerRef.current;
-    if (!container || !data || !data[0] || data[0]?.direction !== 'received') {
+    const latestMessage = data?.[0];
+    if (!latestMessage || latestMessage.direction !== 'received') {
       return;
     }
 
-    const markAsRead = () => {
-      const isScrollable = container.scrollHeight > container.clientHeight;
-      const atBottom = container.scrollTop <= 10;
+    const el = document.getElementById(`msg-${latestMessage.id}`);
+    if (!el) {
+      return;
+    }
 
-      if (!isScrollable || atBottom) {
-        emit('read', { senderId: Number(currentOpeningChat?.id) });
-        dispatch(chatApi.util.invalidateTags([{ type: 'Messages', id: `LIST-${currentOpeningChat?.id}` }]));
-      }
-    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          emit('read', { senderId: Number(currentOpeningChat?.id) });
+          dispatch(chatApi.util.invalidateTags([{ type: 'Messages', id: `LIST-${currentOpeningChat?.id}` }]));
+          observer.disconnect();
+        }
+      },
+      { threshold: 0 },
+    );
 
-    container.addEventListener('scroll', markAsRead);
-    // Check immediately, in case there are not enough messages to scroll
-    markAsRead();
-
-    return () => {
-      container.removeEventListener('scroll', markAsRead);
-    };
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [data, currentOpeningChat?.id, emit, dispatch]);
 
   const playSentMessageSound = () => {
@@ -178,27 +219,46 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
       console.warn('Audio play blocked:', e);
     });
   };
-  const handleSendMessage = async (
-    id: string,
-    text: string,
-    type?: 'txt' | 'img',
-  ) => {
-    if (!text.trim()) {
-      return;
-    }
+  const handleSendMessage = useCallback(
+    async (id: string, text: string, type?: 'txt' | 'img') => {
+      if (!text.trim() || !userInfo) {
+        return;
+      }
 
-    if (!isConnected) {
-      console.warn('[Chat] Cannot send — not connected');
-      return;
-    }
-    emit('send', { recipientId: id, message: text, chatType: type ?? 'txt' });
+      if (!isConnected) {
+        console.warn('[Chat] Cannot send — not connected');
+        return;
+      }
 
-    dispatch(
-      chatApi.util.invalidateTags([{ type: 'Messages', id: `LIST-${id}` }]),
-    );
+      dispatch(
+        chatApi.util.updateQueryData(
+          'getConversation',
+          Number(id),
+          (draft) => {
+            draft.unshift({
+              id: `-${Date.now()}`,
+              from: Number(userInfo.id),
+              to: Number(id),
+              msg: text,
+              chatType: type ?? 'txt',
+              time: new Date().toISOString(),
+              direction: 'sent' as const,
+              isRead: false,
+            });
+          },
+        ),
+      );
 
-    playSentMessageSound();
-  };
+      emit('send', { recipientId: id, message: text, chatType: type ?? 'txt' });
+
+      dispatch(
+        chatApi.util.invalidateTags([{ type: 'Messages', id: `LIST-${id}` }]),
+      );
+
+      playSentMessageSound();
+    },
+    [isConnected, emit, dispatch, userInfo],
+  );
 
   if (!currentOpeningChat) {
     return undefined;
@@ -234,6 +294,7 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
               return (
                 <div
                   key={each.id}
+                  id={`msg-${each.id}`}
                   className={mergeClassnames(
                     'flex',
                     each.direction === 'sent' ? 'justify-end' : 'justify-start',
@@ -252,6 +313,7 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
             return (
               <MessageItem
                 key={each.id}
+                id={`msg-${each.id}`}
                 type={each.direction}
                 participantAvatarUrl={currentOpeningChat?.avatarUrl}
                 markedAsRead={each.direction === 'sent' && each.isRead}

--- a/src/layouts/webapp/MultipleChatWidget.tsx
+++ b/src/layouts/webapp/MultipleChatWidget.tsx
@@ -2,7 +2,7 @@
 
 import { Minus, X } from '@phosphor-icons/react';
 import Image from 'next/image';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { MessageItem, groupMessagesByTime } from './Messages/ChatDetail';
 import IconButton from '@/components/core/iconButton/IconButton';
@@ -120,10 +120,11 @@ type IChatWindowProps = {
 };
 
 const ChatWindow = (props: IChatWindowProps) => {
-  const { data: isOnline } = useGetUserOnlineStatusQuery(props.id, {
+  const { id, onMarkAsRead } = props;
+  const { data: isOnline } = useGetUserOnlineStatusQuery(id, {
     pollingInterval: 10 * 60 * 1000,
   });
-  const { data } = useGetConversationQuery(props.id);
+  const { data } = useGetConversationQuery(id);
   const reversedData = data ? data.toReversed() : [];
   const groupedMessages = groupMessagesByTime(reversedData);
   const lastReadMessageId
@@ -135,55 +136,74 @@ const ChatWindow = (props: IChatWindowProps) => {
 
   const dispatch = useAppDispatch();
 
-  const messageContainerRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
-    const container = messageContainerRef.current;
-    if (!container || !data || !data[0] || data[0]?.direction !== 'received') {
-      return undefined;
+    const latestMessage = data?.[0];
+    if (!latestMessage || latestMessage.direction !== 'received') {
+      return;
     }
 
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const el = document.getElementById(`msg-${latestMessage.id}`);
+    if (!el) {
+      return;
+    }
 
-    const shouldMarkAsRead = () => {
-      const isScrollable = container.scrollHeight > container.clientHeight;
-      const atBottom = container.scrollTop <= 10;
-      if (!isScrollable || atBottom) {
-        // Delay slightly before marking as read
-        if (timeoutId) {
-          clearTimeout(timeoutId);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          onMarkAsRead();
+          dispatch(markAsRead(id));
+          observer.disconnect();
         }
-        timeoutId = setTimeout(() => {
-          props.onMarkAsRead();
-          dispatch(markAsRead(props.id));
-        }, 300);
-      } else if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-    };
+      },
+      { threshold: 0 },
+    );
 
-    shouldMarkAsRead();
-
-    container.addEventListener('scroll', shouldMarkAsRead);
-
-    // Cleanup
-    return () => {
-      container.removeEventListener('scroll', shouldMarkAsRead);
-    };
-  }, [props.id, props.onMarkAsRead, dispatch, data, props]);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [data, id, onMarkAsRead, dispatch]);
 
   const handleMarkParticipantMessageAsRead = () => {
     dispatch(
       chatApi.util.invalidateTags([
-        { type: 'Messages', id: `LIST-${Number(props.id)}` },
+        { type: 'Messages', id: `LIST-${Number(id)}` },
       ]),
     );
   };
+  const handleReceiveMessage = useCallback(
+    (payload: { id: number; from: number; to: number; msg: string; time: number }) => {
+      if (payload.from !== Number(id)) {
+        return;
+      }
+      dispatch(
+        chatApi.util.updateQueryData(
+          'getConversation',
+          Number(id),
+          (draft) => {
+            if (draft.some(m => m.id === String(payload.id))) {
+              return;
+            }
+            draft.unshift({
+              id: String(payload.id),
+              from: payload.from,
+              to: payload.to,
+              msg: payload.msg,
+              chatType: 'txt',
+              time: new Date(payload.time).toISOString(),
+              direction: 'received' as const,
+              isRead: false,
+            });
+          },
+        ),
+      );
+    },
+    [id, dispatch],
+  );
 
   useSocket({
     namespace: 'chat',
     listeners: {
       read: handleMarkParticipantMessageAsRead,
+      receive: handleReceiveMessage,
     },
   });
 
@@ -225,7 +245,6 @@ const ChatWindow = (props: IChatWindowProps) => {
 
       {/* Messages */}
       <div
-        ref={messageContainerRef}
         className="flex flex-1 flex-col-reverse overflow-y-auto bg-green-98 p-3 text-xs leading-5 text-neutral-30"
       >
         {groupedMessages.reverse().map((item, index) => {
@@ -245,6 +264,7 @@ const ChatWindow = (props: IChatWindowProps) => {
             return (
               <div
                 key={message.id}
+                id={`msg-${message.id}`}
                 className={mergeClassnames(
                   'flex',
                   message.direction === 'sent'
@@ -266,6 +286,7 @@ const ChatWindow = (props: IChatWindowProps) => {
           return (
             <MessageItem
               key={message.id}
+              id={`msg-${message.id}`}
               type={message.direction}
               participantAvatarUrl={props.participant.avatarUrl}
               markedAsRead={
@@ -282,7 +303,7 @@ const ChatWindow = (props: IChatWindowProps) => {
 
       {/* Input */}
       <MessengerInput
-        onSend={(value, type) => props.onSend(props.id, value, type)}
+        onSend={(value, type) => props.onSend(id, value, type)}
       />
     </div>
   );
@@ -290,6 +311,7 @@ const ChatWindow = (props: IChatWindowProps) => {
 
 export default function MessengerWidget() {
   const chats = useAppSelector(state => state.messenger.chats);
+  const userInfo = useAppSelector(state => state.auth.userInfo);
 
   const dispatch = useAppDispatch();
 
@@ -304,27 +326,46 @@ export default function MessengerWidget() {
       console.warn('Audio play blocked:', e);
     });
   };
-  const handleSendMessage = async (
-    id: string,
-    text: string,
-    type?: 'txt' | 'img',
-  ) => {
-    if (!text.trim()) {
-      return;
-    }
+  const handleSendMessage = useCallback(
+    async (id: string, text: string, type?: 'txt' | 'img') => {
+      if (!text.trim() || !userInfo) {
+        return;
+      }
 
-    if (!isConnected) {
-      console.warn('[Chat] Cannot send — not connected');
-      return;
-    }
-    emit('send', { recipientId: id, message: text, chatType: type ?? 'txt' });
+      if (!isConnected) {
+        console.warn('[Chat] Cannot send — not connected');
+        return;
+      }
 
-    dispatch(
-      chatApi.util.invalidateTags([{ type: 'Messages', id: `LIST-${id}` }]),
-    );
+      dispatch(
+        chatApi.util.updateQueryData(
+          'getConversation',
+          Number(id),
+          (draft) => {
+            draft.unshift({
+              id: `-${Date.now()}`,
+              from: Number(userInfo.id),
+              to: Number(id),
+              msg: text,
+              chatType: type ?? 'txt',
+              time: new Date().toISOString(),
+              direction: 'sent' as const,
+              isRead: false,
+            });
+          },
+        ),
+      );
 
-    playSentMessageSound();
-  };
+      emit('send', { recipientId: id, message: text, chatType: type ?? 'txt' });
+
+      dispatch(
+        chatApi.util.invalidateTags([{ type: 'Messages', id: `LIST-${id}` }]),
+      );
+
+      playSentMessageSound();
+    },
+    [isConnected, emit, dispatch, userInfo],
+  );
   const openChats = chats.filter(chat => chat.isOpen && !chat.isMinimized);
   const closedChats = chats.filter(chat => !chat.isOpen || chat.isMinimized);
   const handleMinimizeChat = (id: string) => {


### PR DESCRIPTION
…chat

## What this PR does
- [x] Replace scrollTop-based mark-as-read with IntersectionObserver (threshold: 0) matching WhatsApp/Messenger behavior: mark read when message enters viewport
- [x] Insert sent messages into RTK Query cache immediately for instant UI feedback (temp ID replaced by real DB ID on subsequent refetch)

## Related Issue
Related to https://github.com/hulib-engineering/hulib/issues/493

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)
