### PR TITLE
fix: messages page full-viewport layout without external scroll

### DIFF
--- a/src/app/[locale]/(auth)/messages/page.tsx
+++ b/src/app/[locale]/(auth)/messages/page.tsx
@@ -9,12 +9,14 @@ export default function MessagesPage() {
   const [showDetailOnMobile, setShowDetailOnMobile] = useState(false);
 
   return (
-    <>
+    <div className="flex h-full flex-1 flex-col overflow-hidden">
       {/* Mobile version (conditional view) */}
-      <div className="flex w-full flex-1 flex-col bg-neutral-98 lg:hidden">
-        <div className="px-5 py-2 text-xl font-bold leading-7">
-          <h6 className="">Your messages</h6>
-        </div>
+      <div className="flex size-full flex-col overflow-hidden bg-neutral-98 lg:hidden">
+        {!showDetailOnMobile && (
+          <div className="shrink-0 px-5 py-2 text-xl font-bold leading-7">
+            <h6>Your messages</h6>
+          </div>
+        )}
         {!showDetailOnMobile ? (
           <ChatList onConvoSelect={() => setShowDetailOnMobile(true)} />
         ) : (
@@ -26,9 +28,9 @@ export default function MessagesPage() {
       </div>
 
       {/* Desktop version (always both visible) */}
-      <div className="hidden size-full h-screen flex-1 lg:flex">
-        <div className="flex w-[25rem] flex-col border-r border-t border-neutral-90">
-          <div className="bg-white px-4 py-5 text-[28px] font-bold leading-9">
+      <div className="hidden size-full flex-1 overflow-hidden bg-neutral-98 lg:flex">
+        <div className="flex h-full w-[25rem] shrink-0 flex-col border-r border-t border-neutral-90 bg-white">
+          <div className="shrink-0 bg-white px-4 py-5 text-[28px] font-bold leading-9">
             <h4>Messages</h4>
           </div>
           <ChatList />
@@ -36,6 +38,6 @@ export default function MessagesPage() {
 
         <ChatDetail />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/layouts/webapp/Messages/ChatDetail.tsx
+++ b/src/layouts/webapp/Messages/ChatDetail.tsx
@@ -142,6 +142,14 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
   const { data } = useGetConversationQuery(currentOpeningChat?.id, {
     skip: !currentOpeningChat,
   });
+  const reversedData = data ? data.toReversed() : [];
+  const groupedMessages = groupMessagesByTime(reversedData);
+  const lastReadMessageId
+    = (data
+      && data?.filter(
+        (msg: TransformedMessage) => msg.direction === 'sent' && msg.isRead,
+      )[0]?.id)
+      ?? null;
 
   const handleReceiveMessage = useCallback(
     (payload: { id: number; from: number; to: number; msg: string; time: number }) => {
@@ -275,7 +283,7 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
         </Button>
       </div>
       <div className="flex flex-1 flex-col bg-green-98">
-        <div className="flex gap-4 border-t border-neutral-90 bg-white px-[13px] py-[11px] shadow-sm">
+        <div className="flex gap-4 border-neutral-90 bg-white px-[13px] py-[11px] shadow-sm md:border-t">
           <Avatar size="lg" imageUrl={currentOpeningChat?.avatarUrl}>
             <Avatar.Status>
               <StatusBadge onLine={isOnline} />
@@ -287,38 +295,54 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
         </div>
         <div
           ref={messageContainerRef}
-          className="flex max-h-screen flex-1 flex-col-reverse overflow-y-auto"
+          className="flex flex-1 flex-col-reverse overflow-y-auto"
         >
-          {data && data.map((each: TransformedMessage) => {
-            if (each.chatType === 'img') {
+          {groupedMessages.reverse().map((item, index) => {
+            if (item.type === 'separator') {
               return (
                 <div
-                  key={each.id}
-                  id={`msg-${each.id}`}
+                  key={`separator-${index}`}
+                  className="py-2 text-center text-sm leading-5 text-neutral-30"
+                >
+                  {item.label}
+                </div>
+              );
+            }
+
+            const { message } = item;
+            if (message.chatType === 'img') {
+              return (
+                <div
+                  key={message.id}
+                  id={`msg-${message.id}`}
                   className={mergeClassnames(
                     'flex',
-                    each.direction === 'sent' ? 'justify-end' : 'justify-start',
+                    message.direction === 'sent' ? 'justify-end' : 'justify-start',
                   )}
                 >
                   <Image
-                    alt={`Sticker ${each.msg}`}
+                    alt={`Sticker ${message.msg}`}
                     width={120}
                     height={120}
                     className="size-[120px] object-contain"
-                    src={each.stickerUrl ?? ''}
+                    src={message.stickerUrl ?? ''}
                   />
                 </div>
               );
             }
             return (
               <MessageItem
-                key={each.id}
-                id={`msg-${each.id}`}
-                type={each.direction}
+                key={message.id}
+                id={`msg-${message.id}`}
+                type={message.direction}
                 participantAvatarUrl={currentOpeningChat?.avatarUrl}
-                markedAsRead={each.direction === 'sent' && each.isRead}
+                markedAsRead={
+                  message.id === lastReadMessageId
+                  && message.direction === 'sent'
+                  && message.isRead
+                }
               >
-                {each.msg}
+                {message.msg}
               </MessageItem>
             );
           })}

--- a/src/layouts/webapp/Messages/ChatList.tsx
+++ b/src/layouts/webapp/Messages/ChatList.tsx
@@ -159,7 +159,7 @@ export default function ChatList({ onConvoSelect }: { onConvoSelect?: () => void
           onChange={event => setQString(event.target.value)}
         />
       </div>
-      <div className="flex flex-1 flex-col overflow-y-auto">
+      <div className="flex flex-1 flex-col overflow-y-auto bg-white">
         {filteredConversations.map((contact: Contact) => (
           <ContactItem
             key={contact.participant.id}

--- a/src/templates/MainTemplate.tsx
+++ b/src/templates/MainTemplate.tsx
@@ -107,12 +107,12 @@ const MainTemplate = (props: WithChildren) => {
       >
         <div className="flex size-full flex-col">
           <Header />
-          <main className="flex-1 overflow-y-auto bg-neutral-98">
-            <div className="min-h-[calc(100vh-410px)] bg-neutral-98">
+          <main className={mergeClassnames('flex-1 bg-neutral-98', !pathname.includes('messages') && 'overflow-y-auto')}>
+            <div className={mergeClassnames('bg-neutral-98', pathname.includes('messages') ? 'h-full' : 'min-h-[calc(100vh-410px)]')}>
               {props.children}
             </div>
 
-            <FooterWebApp />
+            {!pathname.includes('messages') && <FooterWebApp />}
           </main>
           {!pathname.includes('messages') && <MessengerWidget />}
         </div>


### PR DESCRIPTION
## What this PR does
- [x] Make MessagesPage a true full-viewport height layout (no outer page scroll)
- [x] Fix ChatDetail message container: remove max-h-screen, use flex-1 for proper fill behavior within constrained parent
- [x] Fix markedAsRead: only show read avatar on last read message (matching MultipleChatWidget behavior) 

## Related Issue
Closes #493 

## Screenshots
<img width="1587" height="1040" alt="image" src="https://github.com/user-attachments/assets/7f7b4c29-9ed1-4fe1-8f5c-d857512a63d3" />
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/54f26c19-a048-4696-951f-a2dd9a35f5da" />
<img width="390" height="844" alt="image" src="https://github.com/user-attachments/assets/56a21dfc-cb9e-4b39-a31c-7e706d1fc4cf" />

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)
