### PR TITLE
fix: #492 Landing page/homepage wording

### DIFF
--- a/src/layouts/index/HuberCTA.tsx
+++ b/src/layouts/index/HuberCTA.tsx
@@ -61,11 +61,11 @@ export default function HuberCTA() {
           )}
 
           {!isMobile ? (
-            <h6 className="text-xl font-medium leading-[28px] text-primary-10">
+            <h6 className="text-center text-xl font-medium leading-[28px] text-primary-10">
               {t('short_descriptions.subtitle')}
             </h6>
           ) : (
-            <p className="text-sm text-primary-10">
+            <p className="text-center text-sm text-primary-10">
               {t('short_descriptions.subtitle')}
             </p>
           )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -114,7 +114,7 @@
       "description": "Our vision is to create a safe and proactive community, offering support from human books, to promote well-being and shared experiences."
     },
     "outstanding_features_title": "ngôi nhà của chúng tớ",
-    "outstanding_features_description": "HULIB - Nền tảng kết nối trực tuyến",
+    "outstanding_features_description": "HULIB - Youth Wellbeing Platform",
     "outstanding_features": {
       "index_0": {
         "heading": "Human Book Collection",
@@ -627,7 +627,7 @@
     "short_descriptions": {
       "title": "Become our Huber",
       "btn": "Join as Huber",
-      "subtitle": "Short description"
+      "subtitle": "Every story is a puzzle"
     },
     "no_data": "No Data"
   },

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -783,7 +783,7 @@
     "short_descriptions": {
       "title": "Trở thành Huber của chúng tôi",
       "btn": "Tham gia với tư cách Huber",
-      "subtitle": "Mô tả ngắn gọn"
+      "subtitle": "Mỗi câu chuyện là 1 mảnh ghép 🧩"
     },
     "no_data": "Không có dữ liệu"
   },


### PR DESCRIPTION
## What this PR does
- [x] Landing page/homepage wording

## Related Issue
#492

## Screenshots
<img width="941" height="349" alt="image" src="https://github.com/user-attachments/assets/aa033670-019b-46e9-a89e-94a7d0fdad12" />
<img width="918" height="347" alt="image" src="https://github.com/user-attachments/assets/840754d2-20aa-4bcd-9a52-65fca4b40b32" />

<img width="804" height="141" alt="image" src="https://github.com/user-attachments/assets/00507898-024e-43cf-ac4a-fb82e73f25a7" />

<img width="748" height="152" alt="image" src="https://github.com/user-attachments/assets/9b7b7a93-c3dd-450f-8d3c-b31c391f7da7" />

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted mobile subtitle element styling in the CTA card for improved layout consistency.

* **Chores**
  * Updated subtitle text across English and Vietnamese locales to "Every story is a puzzle."
  * Updated English locale description for the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hulib-engineering/hulib/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->