### PR TITLE
fix: mark-as-read on chat open with idempotency and visibility guards

### DIFF
--- a/src/layouts/webapp/Messages/ChatDetail.tsx
+++ b/src/layouts/webapp/Messages/ChatDetail.tsx
@@ -149,12 +149,24 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
       ?? null;
 
   const emitRef = useRef<(event: string, ...args: any[]) => void>(() => {});
+  const isVisibleRef = useRef(true);
+  const lastAckedUnreadIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const handler = () => {
+      isVisibleRef.current = document.visibilityState === 'visible';
+    };
+    document.addEventListener('visibilitychange', handler);
+    isVisibleRef.current = document.visibilityState === 'visible';
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, []);
 
   const handleReceiveMessage = useCallback(
     (payload: { id: number; from: number; to: number; msg: string; time: number }) => {
       if (!currentOpeningChat || payload.from !== Number(currentOpeningChat.id)) {
         return;
       }
+      const isVisible = isVisibleRef.current;
       dispatch(
         chatApi.util.updateQueryData(
           'getConversation',
@@ -171,16 +183,18 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
               chatType: 'txt',
               time: new Date(payload.time).toISOString(),
               direction: 'received' as const,
-              isRead: true,
+              isRead: isVisible,
             });
           },
         ),
       );
-      emitRef.current('read', { senderId: payload.from });
-      dispatch(chatApi.util.invalidateTags([
-        { type: 'Messages', id: `LIST-${currentOpeningChat.id}` },
-        { type: 'Messages', id: 'LIST' },
-      ]));
+      if (isVisible) {
+        emitRef.current('read', { senderId: payload.from });
+        dispatch(chatApi.util.invalidateTags([
+          { type: 'Messages', id: `LIST-${currentOpeningChat.id}` },
+          { type: 'Messages', id: 'LIST' },
+        ]));
+      }
     },
     [currentOpeningChat, dispatch],
   );
@@ -202,19 +216,37 @@ export default function ChatDetail({ onBack, isTypeFixed = false }: { isTypeFixe
     }
   }, [data]);
   useEffect(() => {
-    if (!data || !currentOpeningChat || !emit) {
+    if (!data || !currentOpeningChat || !emit || !isVisibleRef.current) {
       return;
     }
-    const hasUnreadReceived = data.some(
-      (m: TransformedMessage) => m.direction === 'received' && !m.isRead,
-    );
-    if (hasUnreadReceived) {
-      emit('read', { senderId: Number(currentOpeningChat.id) });
-      dispatch(chatApi.util.invalidateTags([
-        { type: 'Messages', id: `LIST-${currentOpeningChat.id}` },
-        { type: 'Messages', id: 'LIST' },
-      ]));
+    const newestUnreadId
+      = data.find(
+        (m: TransformedMessage) => m.direction === 'received' && !m.isRead,
+      )?.id ?? null;
+    if (!newestUnreadId || newestUnreadId === lastAckedUnreadIdRef.current) {
+      return;
     }
+    lastAckedUnreadIdRef.current = newestUnreadId;
+
+    dispatch(
+      chatApi.util.updateQueryData(
+        'getConversation',
+        Number(currentOpeningChat.id),
+        (draft) => {
+          draft.forEach((m: TransformedMessage) => {
+            if (m.direction === 'received' && !m.isRead) {
+              m.isRead = true;
+            }
+          });
+        },
+      ),
+    );
+
+    emit('read', { senderId: Number(currentOpeningChat.id) });
+    dispatch(chatApi.util.invalidateTags([
+      { type: 'Messages', id: `LIST-${currentOpeningChat.id}` },
+      { type: 'Messages', id: 'LIST' },
+    ]));
   }, [data, currentOpeningChat, emit, dispatch]);
 
   const playSentMessageSound = () => {

--- a/src/layouts/webapp/MultipleChatWidget.tsx
+++ b/src/layouts/webapp/MultipleChatWidget.tsx
@@ -2,7 +2,7 @@
 
 import { Minus, X } from '@phosphor-icons/react';
 import Image from 'next/image';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { MessageItem, groupMessagesByTime } from './Messages/ChatDetail';
 import IconButton from '@/components/core/iconButton/IconButton';
@@ -136,17 +136,47 @@ const ChatWindow = (props: IChatWindowProps) => {
 
   const dispatch = useAppDispatch();
 
+  const isVisibleRef = useRef(true);
+  const lastAckedUnreadIdRef = useRef<string | null>(null);
+
   useEffect(() => {
-    if (!data || !onMarkAsRead) {
+    const handler = () => {
+      isVisibleRef.current = document.visibilityState === 'visible';
+    };
+    document.addEventListener('visibilitychange', handler);
+    isVisibleRef.current = document.visibilityState === 'visible';
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, []);
+
+  useEffect(() => {
+    if (!data || !onMarkAsRead || !isVisibleRef.current) {
       return;
     }
-    const hasUnreadReceived = data.some(
-      (m: TransformedMessage) => m.direction === 'received' && !m.isRead,
-    );
-    if (hasUnreadReceived) {
-      onMarkAsRead();
-      dispatch(markAsRead(id));
+    const newestUnreadId
+      = data.find(
+        (m: TransformedMessage) => m.direction === 'received' && !m.isRead,
+      )?.id ?? null;
+    if (!newestUnreadId || newestUnreadId === lastAckedUnreadIdRef.current) {
+      return;
     }
+    lastAckedUnreadIdRef.current = newestUnreadId;
+
+    dispatch(
+      chatApi.util.updateQueryData(
+        'getConversation',
+        Number(id),
+        (draft) => {
+          draft.forEach((m: TransformedMessage) => {
+            if (m.direction === 'received' && !m.isRead) {
+              m.isRead = true;
+            }
+          });
+        },
+      ),
+    );
+
+    onMarkAsRead();
+    dispatch(markAsRead(id));
   }, [data, id, onMarkAsRead, dispatch]);
 
   const handleMarkParticipantMessageAsRead = () => {
@@ -162,6 +192,7 @@ const ChatWindow = (props: IChatWindowProps) => {
       if (payload.from !== Number(id)) {
         return;
       }
+      const isVisible = isVisibleRef.current;
       dispatch(
         chatApi.util.updateQueryData(
           'getConversation',
@@ -178,13 +209,15 @@ const ChatWindow = (props: IChatWindowProps) => {
               chatType: 'txt',
               time: new Date(payload.time).toISOString(),
               direction: 'received' as const,
-              isRead: true,
+              isRead: isVisible,
             });
           },
         ),
       );
-      onMarkAsRead();
-      dispatch(markAsRead(id));
+      if (isVisible) {
+        onMarkAsRead();
+        dispatch(markAsRead(id));
+      }
     },
     [id, onMarkAsRead, dispatch],
   );


### PR DESCRIPTION
## What this PR does
- [x] Replace scroll/viewport-based mark-as-read with open-conversation model (match Facebook/WhatsApp: all received marked read when chat opens)

## Related Issue
Related to https://github.com/hulib-engineering/hulib/issues/493

---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [x] Related issue is linked (if applicable)
