### PR TITLE
feat: move first book created modal to homepage

### DIFF
--- a/src/app/[locale]/(auth)/users/[id]/_components/MyStoriesPanel.tsx
+++ b/src/app/[locale]/(auth)/users/[id]/_components/MyStoriesPanel.tsx
@@ -13,7 +13,6 @@ import type { Topic } from '@/libs/services/modules/user/userType';
 import Modal from '@/components/Modal';
 import type { Story as TStory } from '@/libs/services/modules/stories/storiesType';
 import StoryForm from '@/features/stories/components/StoryForm';
-import FirstBookCreatedModal from '@/features/stories/components/FirstBookCreatedModal';
 import { StoriesSkeleton } from '@/components/loadingState/Skeletons';
 
 type TTopic = {
@@ -42,7 +41,6 @@ export default function MyStoriesPanel({ topics, storyOwnerId, showOthers = fals
   );
 
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [isFirstBookModalOpen, setIsFirstBookModalOpen] = useState(false);
   const [selectedTopicIds, setSelectedTopicIds] = useState<number[]>(topics.map(topic => topic.topicId));
 
   const handleTopicChipClick = (topicId: number) => {
@@ -61,10 +59,6 @@ export default function MyStoriesPanel({ topics, storyOwnerId, showOthers = fals
 
   const handleBookSubmitSuccess = () => {
     setIsCreateModalOpen(false);
-
-    /* MISSING: Conditions that determine if the user hasn't submitted a book before */
-
-    setIsFirstBookModalOpen(true);
   };
 
   if (isLoading) {
@@ -147,8 +141,6 @@ export default function MyStoriesPanel({ topics, storyOwnerId, showOthers = fals
                   <Plus className="text-xl text-white" />
                 </div>
               </IconButton>
-              {/* DEBUGGING NOTE for 'Feat/UI notice approved story book':
-              - Temporarily change the below function ("setIsCreateModalOpen") to "setIsFirstBookModalOpen" to test out the feature screen quickly. */}
               <Button size="lg" onClick={() => setIsCreateModalOpen(true)}>
                 Create New Story
               </Button>
@@ -176,20 +168,6 @@ export default function MyStoriesPanel({ topics, storyOwnerId, showOthers = fals
             onCancel={() => setIsCreateModalOpen(false)}
           />
         </Modal.Panel>
-      </Modal>
-
-      {/* FirstBookCreatedModal */}
-      <Modal
-        open={isFirstBookModalOpen}
-        onClose={() => setIsFirstBookModalOpen(false)}
-      >
-        <Modal.Backdrop />
-        <Modal.Panel className="w-full shadow-none lg:w-5/6 lg:max-w-6xl">
-          <FirstBookCreatedModal
-            onClose={() => setIsFirstBookModalOpen(false)}
-          />
-        </Modal.Panel>
-
       </Modal>
     </div>
   );

--- a/src/features/stories/components/FirstBookCreatedModal.tsx
+++ b/src/features/stories/components/FirstBookCreatedModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { CalendarDot, X } from '@phosphor-icons/react';
+import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import Button from '@/components/core/button/Button';
 
@@ -7,7 +8,9 @@ type FBModal = | {
   onClose: () => void;
 };
 
-export default function FirstBookCreatedModal(props: FBModal) {
+export default function FirstBookCreatedModal({ onClose }: FBModal) {
+  const t = useTranslations('FirstBookCreated');
+
   return (
     <div className="flex size-full max-h-[900px]
             max-w-[400px] flex-col items-center gap-20 rounded-2xl
@@ -17,7 +20,7 @@ export default function FirstBookCreatedModal(props: FBModal) {
       <button
         type="button"
         className="absolute right-5 top-5 p-3"
-        onClick={props.onClose}
+        onClick={onClose}
         aria-label="Close"
       >
         <X size={20} />
@@ -36,7 +39,7 @@ export default function FirstBookCreatedModal(props: FBModal) {
             <div className="size-full max-h-[72px] max-w-[241px] text-center text-[20px]
                             font-medium tracking-[-0.02em] text-[#0442BF] sm:max-w-[331px] sm:text-[28px] sm:leading-9"
             >
-              <span className="max-sm:text-black">Chào mừng bạn đến với cộng đồng</span>
+              <span className="max-sm:text-black">{t('welcome_title')}</span>
               {' '}
               <b>Huber</b>
               {' '}
@@ -45,7 +48,7 @@ export default function FirstBookCreatedModal(props: FBModal) {
             <div className="w-full max-w-[335px] text-center
                             text-[14px] font-[375] sm:max-w-[480px] sm:text-[16px]"
             >
-              Cuốn sách đầu tiên của bạn đã được duyệt, bây giờ mọi người có thể xem câu chuyện của bạn
+              {t('welcome_description')}
             </div>
           </div>
         </div>
@@ -66,23 +69,24 @@ export default function FirstBookCreatedModal(props: FBModal) {
               <div className="size-full max-w-[225px] text-[16px] font-medium leading-7 tracking-[-0.01em]
                                 text-black sm:max-h-[38px] sm:text-[20px]"
               >
-                Cập nhật lịch của bạn
+                {t('update_schedule_title')}
               </div>
-              <div className="h-full text-[14px] text-sm font-[375] not-italic leading-[22px]
+              <div className="h-full text-sm font-[375] not-italic leading-[22px]
                                 tracking-[0.015em] text-black sm:max-h-[44px]"
               >
-                Cập nhật lịch của bạn để mọi người có thể trò chuyện trực tiếp với bạn
+                {t('update_schedule_description')}
               </div>
             </div>
           </div>
           {/* 2. Button */}
+          {/* TODO: need add action */}
           <Button
-            onClick={() => {}}
+            onClick={onClose}
             className="flex size-full max-w-[342px] items-center justify-center gap-2 rounded-full border border-solid border-[#0442BF]
                       px-4 font-[375] sm:max-w-[448px]"
             iconLeft={<CalendarDot size={20} />}
           >
-            Cập nhật lịch cá nhân
+            {t('update_schedule_button')}
           </Button>
         </div>
       </div>

--- a/src/features/users/types/index.ts
+++ b/src/features/users/types/index.ts
@@ -55,4 +55,5 @@ export type User = {
   }[];
   works: (z.infer<typeof WorkExperienceValidation> & { id: number })[];
   educations: (z.infer<typeof EducationValidation> & { id: number })[];
+  hasSeenHuberOnboarding: boolean;
 };

--- a/src/libs/services/modules/auth/index.ts
+++ b/src/libs/services/modules/auth/index.ts
@@ -20,6 +20,7 @@ import addEducation from './addEducation';
 import editEducation from './editEducation';
 
 import type { Topic } from '@/libs/services/modules/topics/topicType';
+import markHuberOnboardingSeen from '@/libs/services/modules/auth/markHuberOnboardingSeen';
 
 type Enum = {
   id: number;
@@ -42,6 +43,7 @@ export type User = {
   parentFullname?: string;
   photo?: { id: string; path: string };
   sharingTopics?: Topic[];
+  hasSeenHuberOnboarding: boolean;
   // createdAt: Date;
   // updatedAt: Date;
   // deletedAt?: Date;
@@ -78,6 +80,7 @@ export const authApi = authenticationApiWithTag.injectEndpoints({
     editWorkExperience: editWorkExperience(build),
     addEducation: addEducation(build),
     editEducation: editEducation(build),
+    markHuberOnboardingSeen: markHuberOnboardingSeen(build),
   }),
   overrideExisting: false,
 });
@@ -99,4 +102,5 @@ export const {
   useEditWorkExperienceMutation,
   useAddEducationMutation,
   useEditEducationMutation,
+  useMarkHuberOnboardingSeenMutation,
 }: any = authApi;

--- a/src/libs/services/modules/auth/markHuberOnboardingSeen.ts
+++ b/src/libs/services/modules/auth/markHuberOnboardingSeen.ts
@@ -1,0 +1,11 @@
+import type { BaseQueryFn, EndpointBuilder } from '@reduxjs/toolkit/query';
+
+export default (build: EndpointBuilder<BaseQueryFn, string, string>) =>
+  build.mutation({
+    query: (body: { id: string | number }) => ({
+      url: 'auth/me/huber-onboarding/seen',
+      method: 'PATCH',
+      body,
+    }),
+    invalidatesTags: [{ type: 'User', id: 'ME' }],
+  });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,13 @@
       "description": "We cannot find any result that matches your search. Please try search again."
     }
   },
+  "FirstBookCreated": {
+    "welcome_title": "Welcome to the community",
+    "welcome_description": "Your first book has been approved. Everyone can now see your story",
+    "update_schedule_title": "Ready to connect?",
+    "update_schedule_description": "Set your availability so Liber can reach out to you",
+    "update_schedule_button": "Update personal schedule"
+  },
   "Footer": {
     "copyright": "© 2026 HuLib. All rights reserved.",
     "privacy_policy": "privacy policy",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -48,6 +48,13 @@
       "description": "Chúng tôi không tìm thấy kết quả nào phù hợp với tìm kiếm của bạn. Vui lòng thử tìm kiếm lại."
     }
   },
+  "FirstBookCreated": {
+    "welcome_title": "Chào mừng bạn đến với cộng đồng",
+    "welcome_description": "Cuốn sách đầu tiên của bạn đã được duyệt, bây giờ mọi người có thể xem câu chuyện của bạn",
+    "update_schedule_title": "Bạn đã sẵn sàng để kết nối cùng Liber chưa?",
+    "update_schedule_description": "Hãy cập nhật thời gian rảnh để Liber có thể liên hệ với bạn nhé",
+    "update_schedule_button": "Cập nhật lịch cá nhân"
+  },
   "Footer": {
     "footer_description": "Ẩn sâu bên trong chúng ta đều có một câu chuyện và trải nghiệm, vì vậy chúng ta được sinh ra để là một ai đó.",
     "copyright": "© 2026 HuLib. Đã đăng ký bản quyền.",

--- a/src/templates/HomeTemplateInner.tsx
+++ b/src/templates/HomeTemplateInner.tsx
@@ -3,7 +3,7 @@
 import localFont from 'next/font/local';
 import { usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 import PublicHeader from './PublicHeader';
 import Header from '@/app/[locale]/(auth)/_components/Header';
@@ -12,8 +12,13 @@ import CustomToastifyContainer from '@/components/CustomToastifyContainer';
 import { mergeClassnames } from '@/components/core/private/utils';
 import MessengerWidget from '@/layouts/webapp/MultipleChatWidget';
 import { useAppDispatch } from '@/libs/hooks';
-import { useGetPersonalInfoQuery } from '@/libs/services/modules/auth';
+import FirstBookCreatedModal from '@/features/stories/components/FirstBookCreatedModal';
+import {
+  useGetPersonalInfoQuery,
+  useMarkHuberOnboardingSeenMutation,
+} from '@/libs/services/modules/auth';
 import { setAvatarUrl, setUserInfo } from '@/libs/store/authentication';
+import Modal from '@/components/Modal';
 
 const poppins = localFont({
   src: [
@@ -42,13 +47,24 @@ export default function HomeTemplateInner({ children }: { children: ReactNode })
   const { data: personalInfo } = useGetPersonalInfoQuery(undefined, {
     skip: !isAuthenticated,
   });
+  const [markSeen] = useMarkHuberOnboardingSeenMutation();
+
+  const [isFirstBookModalOpen, setIsFirstBookModalOpen] = useState(false);
 
   useEffect(() => {
     if (personalInfo) {
       dispatch(setUserInfo(personalInfo));
       dispatch(setAvatarUrl(personalInfo.photo));
+      if (personalInfo?.role?.name === 'Huber' && !personalInfo?.hasSeenHuberOnboarding) {
+        setIsFirstBookModalOpen(true);
+      }
     }
   }, [personalInfo, dispatch]);
+
+  const handleCloseModal = () => {
+    setIsFirstBookModalOpen(false);
+    markSeen(personalInfo?.id);
+  };
 
   if (isAuthenticated) {
     return (
@@ -64,6 +80,20 @@ export default function HomeTemplateInner({ children }: { children: ReactNode })
           {!pathname.includes('messages') && <MessengerWidget />}
         </div>
         <CustomToastifyContainer />
+        {/* FirstBookCreatedModal */}
+        <Modal
+          open={isFirstBookModalOpen}
+          onClose={handleCloseModal}
+        >
+          <Modal.Backdrop />
+          <Modal.Panel className="w-full shadow-none lg:w-5/6 lg:max-w-6xl">
+            <FirstBookCreatedModal
+              onClose={handleCloseModal}
+            />
+          </Modal.Panel>
+
+        </Modal>
+
       </div>
     );
   }


### PR DESCRIPTION
## What this PR does
- [ ] Add something new
- [ ] Fix some issues

## Related Issue
<!-- Link to related GitHub issue -->
<!-- Example: Fixes #123, Closes #456, Related to #789 -->

## Screenshots
<!-- Add screenshots or recordings if the PR includes UI/visual changes -->
<!-- Drag & drop images here or paste URLs -->
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/911a2019-8528-4426-9864-c51297da82fc" />

---

**Checklist**
- [ ] Code builds without errors
- [ ] Changes are tested locally
- [ ] Related issue is linked (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an onboarding “first book created” prompt for eligible signed-in users.
  * Users can dismiss the prompt, and onboarding completion is now recorded so it won’t appear again.

* **Bug Fixes**
  * Creating a story no longer opens an additional extra modal after submission.
  * Improved the onboarding modal close and CTA actions for a smoother experience.
  * Updated the prompt messaging to use localized text (including English and Vietnamese).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->