### PR TITLE
feat: add responsive UI layouts for create book screens

### DIFF
--- a/src/app/[locale]/(unauth)/register-huber/_components/AgreementCheckbox.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/AgreementCheckbox.tsx
@@ -10,12 +10,13 @@ type AgreementCheckboxProps = {
 export default function AgreementCheckbox({ checked, onChange }: AgreementCheckboxProps) {
   const t = useTranslations('Huber');
   return (
-    <div className="mb-8 rounded-[8px] border border-gray-200 bg-[#F0F5FF] px-5 py-4">
+    <div className="rounded-[8px] border border-gray-200 bg-[#F0F5FF] px-5 py-4">
       <div
         className="flex cursor-pointer items-start gap-3"
         onClick={() => onChange(!checked)}
         role="presentation"
       >
+        {/* 1. Checkbox */}
         <div className="relative mt-0.5 shrink-0">
           <input
             id="agreement-checkbox"
@@ -36,11 +37,13 @@ export default function AgreementCheckbox({ checked, onChange }: AgreementCheckb
             )}
           </div>
         </div>
-        <div className="py-[8px]">
-          <p className="text-[16px] font-[500] leading-[12px] text-[#171819]">
+        <div className="leading-4">
+          {/* 2.1 Upper text */}
+          <p className="text-[16px] font-medium text-[#171819]">
             {t('agreement')}
           </p>
-          <p className="mt-[10px] text-[14px] font-[300] leading-[20px] text-[#171819]">
+          {/* 2.2 Lower text */}
+          <p className="mt-2.5 text-[14px] font-[300] text-[#171819]">
             {t('huber_responsibility')}
           </p>
         </div>

--- a/src/app/[locale]/(unauth)/register-huber/_components/BackButton.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/BackButton.tsx
@@ -9,7 +9,9 @@ export default function BackButton({ text }: BackButtonProps) {
   const buttonText = text ?? t('create_book_title');
 
   return (
-    <div className="mb-8 flex w-full items-center gap-4 px-[96px] py-[18px] shadow-[0_0_6px_0_rgba(0,0,0,0.12)]">
+    <div className="flex w-full items-center gap-4 px-24 py-[18px] shadow-[0_0_6px_0_rgba(0,0,0,0.12)]
+      max-md:gap-3 max-md:px-4 max-md:pb-2"
+    >
       <button
         onClick={() => history.back()}
         className="flex size-8 items-center justify-center rounded-full transition-colors hover:bg-gray-100"
@@ -19,7 +21,12 @@ export default function BackButton({ text }: BackButtonProps) {
           <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
         </svg>
       </button>
-      <h1 className="text-[32px] font-[500] leading-[40px] text-gray-900">{buttonText}</h1>
+      <h1
+        className="text-[32px] font-medium leading-[40px] text-gray-900
+        max-md:text-[20px]"
+      >
+        {buttonText}
+      </h1>
     </div>
   );
 }

--- a/src/app/[locale]/(unauth)/register-huber/_components/BackButton.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/BackButton.tsx
@@ -9,24 +9,29 @@ export default function BackButton({ text }: BackButtonProps) {
   const buttonText = text ?? t('create_book_title');
 
   return (
-    <div className="flex w-full items-center gap-4 px-24 py-[18px] shadow-[0_0_6px_0_rgba(0,0,0,0.12)]
-      max-md:gap-3 max-md:px-4 max-md:pb-2"
-    >
-      <button
-        onClick={() => history.back()}
-        className="flex size-8 items-center justify-center rounded-full transition-colors hover:bg-gray-100"
-        aria-label={t('back')}
+    <div className="pb-16 sm:pb-20">
+      <div className="fixed top-0 z-40
+        flex w-full items-center gap-4 bg-white px-24
+        py-[18px]
+        shadow-[0_0_6px_0_rgba(0,0,0,0.12)]
+        max-md:gap-3 max-md:px-4 max-md:pb-2"
       >
-        <svg className="size-5 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-          <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
-        </svg>
-      </button>
-      <h1
-        className="text-[32px] font-medium leading-[40px] text-gray-900
-        max-md:text-[20px]"
-      >
-        {buttonText}
-      </h1>
+        <button
+          onClick={() => history.back()}
+          className="flex size-8 items-center justify-center rounded-full transition-colors hover:bg-gray-100"
+          aria-label={t('back')}
+        >
+          <svg className="size-5 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18" />
+          </svg>
+        </button>
+        <h1
+          className="text-[32px] font-medium leading-[40px] text-gray-900
+          max-md:text-[20px]"
+        >
+          {buttonText}
+        </h1>
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/(unauth)/register-huber/_components/ContinueButton.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/ContinueButton.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { useTranslations } from 'next-intl';
 
-type FooterBarProps = {
+type ContinueButtonProps = {
   canContinue: boolean;
   onContinue: () => void;
 };
 
-export default function ContinueButton({ canContinue, onContinue }: FooterBarProps) {
+export default function ContinueButton({ canContinue, onContinue }: ContinueButtonProps) {
   const t = useTranslations('Huber');
 
   return (

--- a/src/app/[locale]/(unauth)/register-huber/_components/ContinueButton.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/ContinueButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+import { useTranslations } from 'next-intl';
+
+type FooterBarProps = {
+  canContinue: boolean;
+  onContinue: () => void;
+};
+
+export default function ContinueButton({ canContinue, onContinue }: FooterBarProps) {
+  const t = useTranslations('Huber');
+
+  return (
+    <button
+      onClick={onContinue}
+      disabled={!canContinue}
+      className={`shrink-0 rounded-full px-8 py-3 text-sm font-semibold transition-colors
+        ${canContinue
+      ? 'cursor-pointer bg-primary-50 text-white hover:bg-indigo-600'
+      : 'bg-[#E3E4E5] text-[#ABAEB1]'
+    } h-[44px] max-sm:w-full sm:w-[250px]`}
+    >
+      {t('continue')}
+    </button>
+  );
+}

--- a/src/app/[locale]/(unauth)/register-huber/_components/EmergencyNotice.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/EmergencyNotice.tsx
@@ -1,0 +1,24 @@
+'use client';
+import Image from 'next/image';
+import { useTranslations } from 'next-intl';
+
+export default function EmergencyNotice() {
+  const t = useTranslations('Huber');
+
+  return (
+    <div className="flex items-center gap-2
+      rounded-lg border border-[#FFAB67] bg-[#FFF9F5]
+      p-2"
+    >
+      <Image
+        src="/assets/images/register-huber/shield_check.png"
+        alt="Emergency"
+        width={20}
+        height={20}
+      />
+      <p className="text-[14px] font-[500] leading-5 text-[#45484A]">
+        {t('emergency_notice')}
+      </p>
+    </div>
+  );
+}

--- a/src/app/[locale]/(unauth)/register-huber/_components/FooterBar.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/FooterBar.tsx
@@ -1,5 +1,3 @@
-// File no longer in use by (unauth)\register-huber\policy\page.tsx
-
 'use client';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';

--- a/src/app/[locale]/(unauth)/register-huber/_components/FooterBar.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/FooterBar.tsx
@@ -1,3 +1,5 @@
+// File no longer in use by (unauth)\register-huber\policy\page.tsx
+
 'use client';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';

--- a/src/app/[locale]/(unauth)/register-huber/_components/Herobanner.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/Herobanner.tsx
@@ -6,30 +6,51 @@ export default function Herobanner() {
   const t = useTranslations('Huber');
 
   return (
-    <div className="relative mb-8 flex min-h-[140px] items-center overflow-hidden rounded-2xl bg-[#EEF2FF] px-8 pt-6">
-      {/* Mascot */}
-      <div className="relative z-10 mr-8 aspect-[195/130] w-[300px] shrink-0">
+    <div className="relative flex
+      min-h-[160px] items-center
+      overflow-hidden bg-[#EEF2FF]
+      max-[370px]:min-h-[200px] sm:rounded-2xl "
+    >
+      {/* 1. Mascot */}
+      <div className="relative z-10 mr-8 aspect-[195/130] w-[300px] shrink-0 max-md:right-20
+        max-sm:hidden"
+      >
         <Image
           src="/assets/images/register-huber/huber.png"
           alt="Mascot"
           fill
           sizes="100vw"
-          className="object-cover object-center"
+          className="mt-7 object-cover object-center"
           priority
         />
       </div>
 
-      {/* Text */}
-      <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center px-8">
-        <div className="mb-[10px] flex items-center justify-center">
-          <h2 className="m-0 mr-[8px] text-center text-[20px] font-[500] leading-[28px] text-black">
+      <div className="pointer-events-none absolute inset-0
+        flex items-center justify-center
+        gap-3 sm:justify-end min-[1200px]:justify-center "
+      >
+        {/* 2. Text Content */}
+        <div className="flex flex-col gap-3 text-center sm:w-80 min-[950px]:w-[460px]">
+          {/* 2.1 Upper text + Icon */}
+          <h2 className=" text-xl font-medium leading-7 text-black">
+            {/* 2.1.1 Upper text */}
             {t('hero_title')}
+
+            {/* 2.1.2 Mini book icon */}
+            <Image
+              src="/assets/images/register-huber/mini_book.png"
+              alt="mini-book"
+              width={20}
+              height={20}
+              className="ml-1 inline-block"
+            />
           </h2>
-          <Image src="/assets/images/register-huber/mini_book.png" alt="mini-book" width={20} height={20} />
+
+          {/* 2.2 Lower text */}
+          <p className="text-base leading-5 text-[#45484A]">
+            {t('hero_description')}
+          </p>
         </div>
-        <p className="w-[460px] text-center text-[16px] leading-[20px] text-[#45484A]">
-          {t('hero_description')}
-        </p>
       </div>
     </div>
   );

--- a/src/app/[locale]/(unauth)/register-huber/_components/MobileSafetyWarning.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/MobileSafetyWarning.tsx
@@ -1,0 +1,20 @@
+'use client';
+// import { useTranslations } from 'next-intl';
+import { ShieldCheckIcon } from '@phosphor-icons/react';
+
+export default function MobileSafetyWarning() {
+  // const t = useTranslations('Huber');
+
+  return (
+    <div
+      className="mx-4 flex flex-row
+      items-center gap-2 rounded-lg border
+      border-[#FFAB67] bg-[#FFF9F5] p-2 sm:hidden"
+    >
+      <ShieldCheckIcon className="shrink-0" color="#FF7301" />
+      <div className="text-[14px] font-medium text-[#45484A]">
+        Nếu bạn thấy ai đó đang trong tình huống nguy hiểm vui lòng liên hệ ngay dịch vụ hỗ trợ khấn cấp phù hợp.
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/(unauth)/register-huber/_components/RestrictedContent.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/RestrictedContent.tsx
@@ -15,34 +15,36 @@ export default function RestrictedContent() {
   const t = useTranslations('Huber');
 
   return (
-    <div className="mb-[20px] w-full rounded-2xl border border-[#FFE3CC] bg-[#FFF9F5] px-9 py-7">
-      {/* Header */}
-      <div className="mb-5 flex items-center gap-3">
-        <div className="flex items-center justify-center rounded-full bg-[#FFE3CC] p-[8px]">
-          <Image
-            src="/assets/images/register-huber/warning.png"
-            alt="warning"
-            width={30}
-            height={30}
-          />
-        </div>
-        <h3 className="text-[16px] font-[500] leading-[24px] tracking-[0.5%] text-black">Nội dung cần tránh</h3>
-      </div>
-
-      {/* Grid 2 columns */}
-      <div className="grid grid-cols-2 gap-x-12 gap-y-3">
-        {contentKeys.map((key, idx) => (
-          <div key={idx} className="flex items-start gap-2.5">
+    <div className="max-sm:px-4">
+      <div className="w-full rounded-2xl border border-[#FFE3CC] bg-[#FFF9F5] px-3 py-6">
+        {/* Header */}
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex items-center justify-center rounded-full bg-[#FFE3CC] p-2">
             <Image
-              src="/assets/images/register-huber/x_circle.png"
-              alt="x-circle"
-              width={20}
-              height={20}
-              className="mt-0.5"
+              src="/assets/images/register-huber/warning.png"
+              alt="warning"
+              width={30}
+              height={30}
             />
-            <span className="text-[14px] leading-[22px] text-[#171819]">{t(key)}</span>
           </div>
-        ))}
+          <h3 className="text-[16px] font-[500] leading-6 tracking-[0.5%] text-black">Nội dung cần tránh</h3>
+        </div>
+
+        {/* Grid 2 columns */}
+        <div className="grid grid-cols-2 gap-2">
+          {contentKeys.map((key, idx) => (
+            <div key={idx} className="flex items-start gap-2.5 sm:items-center">
+              <Image
+                src="/assets/images/register-huber/x_circle.png"
+                alt="x-circle"
+                width={20}
+                height={20}
+                className="mt-0.5"
+              />
+              <span className="text-[14px] leading-[18px] text-[#171819]">{t(key)}</span>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/app/[locale]/(unauth)/register-huber/_components/Rulecard.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/Rulecard.tsx
@@ -36,8 +36,8 @@ type RuleCardProps = {
 
 export default function Rulecard({ card }: RuleCardProps) {
   return (
-    <div className="flex flex-col rounded-2xl border border-[#CDDDFE] bg-white px-[20px] py-[30px]">
-      <div className="mb-4 flex flex-row items-center justify-center gap-3 ">
+    <div className="flex flex-col rounded-2xl border border-[#CDDDFE] bg-white px-5 py-6">
+      <div className="justify-left mb-4 flex flex-row items-center gap-3 ">
         <div className={`flex h-[48px] w-[48px] shrink-0 items-center justify-center rounded-full ${card.iconBg}`}>
           {card.size === 'small' ? (
             <Image src={card.icon} alt="icon" width={24} height={24} />
@@ -52,7 +52,7 @@ export default function Rulecard({ card }: RuleCardProps) {
           <RuleItem key={idx} type={rule.type} text={rule.text} />
         ))}
       </ul> */}
-      <p className="text-[14px] leading-[22px] tracking-[1.5%] text-[#171819]">{card.rules}</p>
+      <p className="text-[14px] leading-[18px] tracking-[1.5%] text-[#171819]">{card.rules}</p>
     </div>
   );
 }

--- a/src/app/[locale]/(unauth)/register-huber/_components/Rulesgrid.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/_components/Rulesgrid.tsx
@@ -42,7 +42,7 @@ export default function Rulesgrid() {
   ];
 
   return (
-    <div className="mb-8 grid grid-cols-1 gap-[40px] sm:grid-cols-2 lg:grid-cols-5">
+    <div className="grid grid-cols-1 gap-4 max-sm:px-4 min-[405px]:grid-cols-2 lg:grid-cols-5">
       {CARDS.map((card, idx) => (
         <RuleCard key={idx} card={card} />
       ))}

--- a/src/app/[locale]/(unauth)/register-huber/create-book/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/create-book/page.tsx
@@ -7,7 +7,7 @@ export default function CreateBook() {
   return (
     <div className="">
       <BackButton text="Tạo sách" />
-      <div className="px-[96px]">
+      <div className="py-1 xl:px-24">
         <StoryForm type="create" onCancel={() => { }} onSucceed={() => { }} />
       </div>
     </div>

--- a/src/app/[locale]/(unauth)/register-huber/policy/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/policy/page.tsx
@@ -3,11 +3,14 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import AgreementCheckbox from '../_components/AgreementCheckbox';
-import FooterBar from '../_components/FooterBar';
+// import FooterBar from '../_components/FooterBar';
+import EmergencyNotice from '../_components/EmergencyNotice';
+import ContinueButton from '../_components/ContinueButton';
 import HeroBanner from '../_components/Herobanner';
 import RulesGrid from '../_components/Rulesgrid';
 import BackButton from '../_components/BackButton';
 import RestrictedContent from '../_components/RestrictedContent';
+import MobileSafetyWarning from '../_components/MobileSafetyWarning';
 
 export default function RegisterAsHuberPage() {
   const [agreed, setAgreed] = useState(false);
@@ -20,23 +23,47 @@ export default function RegisterAsHuberPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white pb-[60px]">
-      <div className="">
-        {/* Page header */}
-        <BackButton />
+    <div
+      className="flex flex-col gap-6
+      sm:mb-8"
+    >
+      {/* PAGE HEADER */}
+      <BackButton />
 
-        <div className="px-[96px]">
-          {/* Hero banner */}
-          <HeroBanner />
+      {/* PAGE CONTENT */}
+      <div className="flex flex-col
+        gap-4 max-sm:max-h-[calc(100vh-120px)]
+        max-sm:overflow-y-auto
+        max-sm:pb-[180px] sm:gap-8 sm:px-24"
+      >
+        {/* Hero banner */}
+        <HeroBanner />
+        <MobileSafetyWarning />
+        {/* Rules grid */}
+        <RulesGrid />
+        {/* Restricted content */}
+        <RestrictedContent />
 
-          {/* Rules grid */}
-          <RulesGrid />
-          <RestrictedContent />
-          {/* Agreement checkbox */}
+        {/*  Normal UI */}
+        <div className="flex flex-col gap-4 max-sm:hidden">
           <AgreementCheckbox checked={agreed} onChange={setAgreed} />
+          <div className="flex h-full items-center justify-between gap-4">
+            <EmergencyNotice />
+            <ContinueButton canContinue={agreed} onContinue={handleContinue} />
+          </div>
+        </div>
 
-          {/* Footer bar */}
-          <FooterBar canContinue={agreed} onContinue={handleContinue} />
+        {/*  Responsive mobile UI */}
+        <div className="sm:hidden">
+          <EmergencyNotice />
+          <div
+            className="fixed bottom-0 flex flex-col gap-2
+            rounded-t-2xl bg-white
+            px-4 py-3 shadow-[0_0_4px_rgba(15,15,16,0.06)]"
+          >
+            <AgreementCheckbox checked={agreed} onChange={setAgreed} />
+            <ContinueButton canContinue={agreed} onContinue={handleContinue} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/[locale]/(unauth)/register-huber/policy/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/policy/page.tsx
@@ -23,10 +23,7 @@ export default function RegisterAsHuberPage() {
   };
 
   return (
-    <div
-      className="flex flex-col gap-6
-      sm:mb-8"
-    >
+    <div className="flex flex-col sm:mb-8 sm:gap-6">
       {/* PAGE HEADER */}
       <BackButton />
 

--- a/src/app/[locale]/(unauth)/register-huber/success/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/success/page.tsx
@@ -20,98 +20,124 @@ export default function RegisterHuberSuccess() {
     <div className="min-h-screen bg-white">
       <BackButton />
 
-      <div className="flex flex-col items-center px-[96px] pb-16 pt-10">
-        <div className="mb-6">
-          <Image
-            src="/assets/images/register-huber/blue_book.png"
-            alt="Book icon"
-            width={100}
-            height={100}
-            className="object-contain"
-          />
-        </div>
+      <div
+        className="flex flex-col items-center
+        sm:px-[96px] sm:pb-16 sm:pt-10"
+      >
+        <div className="overflow-y-auto px-4 max-sm:max-h-[calc(100vh-88px)] max-sm:pb-24">
+          {/* Top icon */}
+          <div className="mb-6 flex justify-center max-sm:hidden">
+            <Image
+              src="/assets/images/register-huber/blue_book.png"
+              alt="Book icon"
+              width={100}
+              height={100}
+              className="object-contain"
+            />
+          </div>
+          {/* 'Write your success story' */}
+          <h1 className="mb-3 text-center text-[28px] font-[500] leading-[36px] text-[#0442BF] max-sm:hidden">
+            {t('success_create_book')}
+          </h1>
+          {/* Gratitude text */}
+          <p className="mb-10 max-w-md text-center text-[16px] font-[400] leading-[24px] tracking-[0.5%] text-gray-500 max-sm:hidden">
+            {t('thanks_for_story')}
+          </p>
 
-        <h1 className="mb-3 text-center text-[28px] font-[500] leading-[36px] text-[#0442BF]">
-          {t('success_create_book')}
-        </h1>
-
-        <p className="mb-10 max-w-md text-center text-[16px] font-[400] leading-[24px] tracking-[0.5%] text-gray-500">
-          {t('thanks_for_story')}
-        </p>
-
-        {/* Story Card */}
-        <div className="mb-10 flex w-full max-w-[420px] items-start justify-between gap-5 rounded-[16px] border border-[#DDC9EF] bg-[#FAF7FC] p-6 opacity-70">
-          {/* Left: text content */}
-          <div className="flex flex-1 flex-col gap-3">
-            <span className="self-start rounded-full bg-[#7C5CBF] px-4 py-1.5 text-xs font-semibold text-white">
-              {t('in_review')}
-            </span>
-
-            {story?.title && (
-              <p className="text-lg font-semibold leading-6 text-gray-800">
-                {story.title}
-              </p>
-            )}
-
-            {story?.topics && story.topics.length > 0 && (
-              <div className="flex flex-wrap items-center gap-2">
-                {story.topics.slice(0, 1).map((topic: any) => (
-                  <span
-                    key={topic.id}
-                    className="rounded-[4px] border border-[#84ACFC] bg-[#CDDDFE] px-3 py-1 text-xs font-medium text-[#0858FA]"
-                  >
-                    {topic.name}
-                  </span>
-                ))}
-                {story.topics.length > 1 && (
-                  <span className="rounded-[4px] border border-[#84ACFC] bg-[#0858FA] px-3 py-1 text-xs font-medium text-white">
-                    {`+${story.topics.length - 1}`}
-                  </span>
-                )}
-              </div>
-            )}
-
-            <div className="mt-1 flex items-center gap-2">
-              <div className="flex size-6 items-center justify-center rounded-full bg-[#EDEBFB] text-xs">
-                😊
-              </div>
-              <span className="text-sm text-gray-500">
-                {story?.humanBook?.fullName}
+          {/* Story Card */}
+          <div
+            className="mb-10 flex w-full
+            items-start justify-between gap-5
+            rounded-[16px]
+            border p-4
+            shadow-[0_4px_5px_0_rgba(28,30,33,0.1),_0_0_4px_0_rgba(15,15,16,0.06)]
+            max-sm:my-4
+            sm:border-[#DDC9EF] sm:bg-[#FAF7FC] sm:opacity-70"
+          >
+            {/* Left: text content */}
+            <div className="flex flex-1 flex-col gap-3">
+              <span className="self-start rounded-full bg-[#7C5CBF] px-4 py-1.5 text-xs font-semibold text-white">
+                {t('in_review')}
               </span>
+
+              {story?.title && (
+                <p className="text-lg font-semibold leading-6 text-gray-800">
+                  {story.title}
+                </p>
+              )}
+
+              {story?.topics && story.topics.length > 0 && (
+                <div className="flex flex-wrap items-center gap-2">
+                  {story.topics.slice(0, 1).map((topic: any) => (
+                    <span
+                      key={topic.id}
+                      className="rounded-[4px] border border-[#84ACFC] bg-[#CDDDFE] px-3 py-1 text-xs font-medium text-[#0858FA]"
+                    >
+                      {topic.name}
+                    </span>
+                  ))}
+                  {story.topics.length > 1 && (
+                    <span className="rounded-[4px] border border-[#84ACFC] bg-[#0858FA] px-3 py-1 text-xs font-medium text-white">
+                      {`+${story.topics.length - 1}`}
+                    </span>
+                  )}
+                </div>
+              )}
+
+              <div className="mt-1 flex items-center gap-2">
+                <div className="flex size-6 items-center justify-center rounded-full bg-[#EDEBFB] text-xs">
+                  😊
+                </div>
+                <span className="text-sm text-gray-500">
+                  {story?.humanBook?.fullName}
+                </span>
+              </div>
             </div>
+
+            {/* Right: book cover */}
+            {!isLoading && story?.cover?.path && (
+              <div className="relative h-[220px] w-[150px] shrink-0 overflow-hidden rounded-[4px] shadow-[4px_4px_12px_rgba(0,0,0,0.15)]">
+                <Image
+                  src={story.cover.path}
+                  alt={story.title || 'Story cover'}
+                  fill
+                  className="object-cover"
+                />
+
+                {/* Gáy sách giả lập bên trái ảnh */}
+                {/* <div className="absolute inset-y-0 left-0 w-[6px] bg-black/10" /> */}
+
+                {/* Tên tác giả, gạch chân, giữa và sát đáy bìa */}
+                {/* {story?.humanBook?.fullName && (
+                  <div className="absolute inset-x-0 bottom-3 flex justify-center px-2">
+                    <span className="truncate pb-0.5 text-[11px] font-medium text-[#F472B6]">
+                      _{story.humanBook.fullName}_
+                    </span>
+                  </div>
+                )} */}
+              </div>
+            )}
           </div>
 
-          {/* Right: book cover */}
-          {!isLoading && story?.cover?.path && (
-            <div className="relative h-[220px] w-[150px] shrink-0 overflow-hidden rounded-[4px] shadow-[4px_4px_12px_rgba(0,0,0,0.15)]">
-              <Image
-                src={story.cover.path}
-                alt={story.title || 'Story cover'}
-                fill
-                className="object-cover"
-              />
-
-              {/* Gáy sách giả lập bên trái ảnh */}
-              {/* <div className="absolute inset-y-0 left-0 w-[6px] bg-black/10" /> */}
-
-              {/* Tên tác giả, gạch chân, giữa và sát đáy bìa */}
-              {/* {story?.humanBook?.fullName && (
-                <div className="absolute inset-x-0 bottom-3 flex justify-center px-2">
-                  <span className="truncate pb-0.5 text-[11px] font-medium text-[#F472B6]">
-                    _{story.humanBook.fullName}_
-                  </span>
-                </div>
-              )} */}
-            </div>
-          )}
+          {/* Gratitude text - Mobile */}
+          <div className="flex flex-col gap-2 px-4 sm:hidden">
+            <h1 className="text-center text-[28px] font-[500] leading-[36px]"> Viết câu chuyện thành công </h1>
+            <p className="max-w-md text-center text-[16px] font-[400] leading-[24px] tracking-[0.5%] text-gray-500">
+              {t('thanks_for_story')}
+            </p>
+          </div>
         </div>
-
         {/* Action buttons */}
-        <div className="flex gap-4">
-          <button onClick={() => router.push(`/users/${story.humanBookId}?tab=about`)} className="hover:bg-gray-50 h-[44px] w-[232px] rounded-full border border-[#C2C6CF] px-6 py-3 text-sm font-medium text-[#0442BF] transition-colors">
+        <div
+          className="flex gap-4 bg-white p-2 max-sm:fixed max-sm:bottom-0
+          max-sm:w-full max-sm:flex-col
+          max-sm:gap-2 max-sm:rounded-t-2xl
+          max-sm:shadow-[0_0_4px_rgba(15,15,16,0.06)]"
+        >
+          <button onClick={() => router.push(`/users/${story.humanBookId}?tab=about`)} className="hover:bg-gray-50 h-[44px] rounded-full border border-[#C2C6CF] px-6 py-3 text-sm font-medium text-[#0442BF] transition-colors sm:w-[232px]">
             {t('back_to_profile')}
           </button>
-          <button onClick={() => router.push(`/`)} className="flex h-[44px] w-[232px] items-center justify-center gap-2 rounded-full bg-gradient-to-b from-[#007CBE] to-[#8845C6] px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-[#14144a]">
+          <button onClick={() => router.push(`/`)} className="flex h-[44px] items-center justify-center gap-2 rounded-full bg-gradient-to-b from-[#007CBE] to-[#8845C6] px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-[#14144a] sm:w-[232px]">
             <Image
               src="/assets/images/register-huber/white_book.png"
               alt={t('new_book_icon_alt')}

--- a/src/app/[locale]/(unauth)/register-huber/success/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/success/page.tsx
@@ -22,7 +22,7 @@ export default function RegisterHuberSuccess() {
 
       <div
         className="flex flex-col items-center
-        sm:px-[96px] sm:pb-2"
+        sm:px-[96px] sm:pb-16 sm:pt-10"
       >
         <div className="overflow-y-auto px-4 max-sm:max-h-[calc(100vh-88px)] max-sm:pb-24">
           {/* Top icon */}

--- a/src/app/[locale]/(unauth)/register-huber/success/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/success/page.tsx
@@ -22,7 +22,7 @@ export default function RegisterHuberSuccess() {
 
       <div
         className="flex flex-col items-center
-        sm:px-[96px] sm:pb-16 sm:pt-10"
+        sm:px-[96px] sm:pb-2"
       >
         <div className="overflow-y-auto px-4 max-sm:max-h-[calc(100vh-88px)] max-sm:pb-24">
           {/* Top icon */}

--- a/src/app/[locale]/(unauth)/register-huber/success/page.tsx
+++ b/src/app/[locale]/(unauth)/register-huber/success/page.tsx
@@ -109,12 +109,12 @@ export default function RegisterHuberSuccess() {
 
                 {/* Tên tác giả, gạch chân, giữa và sát đáy bìa */}
                 {/* {story?.humanBook?.fullName && (
-                  <div className="absolute inset-x-0 bottom-3 flex justify-center px-2">
-                    <span className="truncate pb-0.5 text-[11px] font-medium text-[#F472B6]">
-                      _{story.humanBook.fullName}_
-                    </span>
-                  </div>
-                )} */}
+                <div className="absolute inset-x-0 bottom-3 flex justify-center px-2">
+                  <span className="truncate pb-0.5 text-[11px] font-medium text-[#F472B6]">
+                    _{story.humanBook.fullName}_
+                  </span>
+                </div>
+              )} */}
               </div>
             )}
           </div>

--- a/src/features/stories/components/StoryForm.tsx
+++ b/src/features/stories/components/StoryForm.tsx
@@ -261,14 +261,17 @@ export default function StoryForm(props: IStoryFormProps) {
       pushError(t(error?.message || 'error_contact_admin'));
     }
   };
-
+  // CHANGE: Changed 'xl' and 'lg' breakpoints to 'sm' or 'md'.
   return (
-    <div className="flex flex-col gap-6 rounded-[20px] bg-white p-5">
+    <div className="flex flex-col gap-6 rounded-[20px] bg-white
+      max-[955px]:mt-2 min-[955px]:p-5"
+    >
       <Form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-stretch lg:gap-6">
-
+        <div className="flex flex-col gap-4 min-[955px]:flex-row
+          min-[955px]:items-stretch min-[955px]:gap-6"
+        >
           {/* Cột trái */}
-          <div className="flex flex-1 flex-col">
+          <div className="flex flex-1 flex-col max-[955px]:hidden">
             <p className="mb-2 text-sm font-medium text-black">
               {t('cover_picture')}
               {' '}
@@ -279,7 +282,7 @@ export default function StoryForm(props: IStoryFormProps) {
             border border-neutral-90 bg-neutral-98 p-5"
             >
               {/* Desktop */}
-              <div className="hidden w-full cursor-pointer flex-col gap-4 xl:flex">
+              <div className="hidden w-full cursor-pointer flex-col gap-4 sm:flex">
                 <div className="flex justify-between gap-2">
                   {COVER_PRESET_ASSETS.map((cover, index) => (
                     <div key={cover} className="flex flex-col gap-2">
@@ -315,63 +318,12 @@ export default function StoryForm(props: IStoryFormProps) {
                   ))}
                 </div>
               </div>
-
-              {/* Mobile */}
-              <div className="mx-auto flex w-full max-w-sm flex-col items-center gap-5 xl:hidden">
-                <Swiper
-                  slidesPerView={1}
-                  spaceBetween={16}
-                  loop={false}
-                  className="w-full"
-                  onSwiper={swiper => (swiperRef = swiper)}
-                  onSlideChange={handleSwipeAndSelectCover}
-                >
-                  {COVER_PRESET_ASSETS.map(cover => (
-                    <SwiperSlide key={cover}>
-                      <div className="flex items-center justify-center">
-                        <CustomCoverBuilder
-                          storyTitle={title.trim() || t('placeholder_title')}
-                          authorName={userInfo?.fullName}
-                          coverImgSrc={
-                            isCustomCoverActive && selectedCoverSample === cover
-                              ? ''
-                              : cover
-                          }
-                          customization={getThumbnailCustomization(cover)}
-                          active={selectedCoverSample === cover}
-                        />
-                      </div>
-                    </SwiperSlide>
-                  ))}
-                </Swiper>
-                <div className="mt-3 flex justify-center space-x-2">
-                  {COVER_PRESET_ASSETS.map((cover, idx) => (
-                    <button
-                      key={cover}
-                      type="button"
-                      className={mergeClassnames(
-                        'size-2 rounded-full transition-all duration-300',
-                        currentCoverIndex === idx ? 'w-10 bg-neutral-80' : 'bg-neutral-90',
-                      )}
-                      onClick={() => swiperRef?.slideTo(idx)}
-                    />
-                  ))}
-                </div>
-                <Button
-                  variant="soft"
-                  size="sm"
-                  className="w-[180px]"
-                  onClick={() => setIsCustomCoverModalOpen(true)}
-                >
-                  {t('custom')}
-                </Button>
-              </div>
             </div>
           </div>
 
           {/* Cột phải */}
           <div className="flex flex-1 flex-col gap-6">
-            <Form.Item>
+            <Form.Item className="max-[955px]:px-4">
               <TextInput
                 {...register('title')}
                 type="text"
@@ -388,7 +340,7 @@ export default function StoryForm(props: IStoryFormProps) {
               />
             </Form.Item>
 
-            <Form.Item>
+            <Form.Item className="max-[955px]:px-4">
               <Combobox
                 // @ts-ignore
                 by="id"
@@ -455,7 +407,7 @@ export default function StoryForm(props: IStoryFormProps) {
               </Combobox>
             </Form.Item>
 
-            <Form.Item>
+            <Form.Item className="max-[955px]:px-4">
               <Label className="mb-2">
                 {t('abstract')}
                 <span className="text-red-50">*</span>
@@ -473,12 +425,82 @@ export default function StoryForm(props: IStoryFormProps) {
                 </p>
               )}
             </Form.Item>
+            {/* Gần dưới cùng */}
+            <div className="flex flex-1 flex-col max-[955px]:px-4 min-[955px]:hidden">
+              <p className="mb-2 text-sm font-medium text-black">
+                {t('cover_picture')}
+                {' '}
+                <span className="text-red-50">*</span>
+              </p>
 
-            <div className="mt-auto flex w-full justify-end">
+              <div className="flex flex-1 rounded-2xl
+            border border-neutral-90 bg-neutral-98 p-5"
+              >
+                {/* Mobile */}
+                <div className="mx-auto flex w-full max-w-sm flex-col items-center gap-5">
+                  <Swiper
+                    slidesPerView={1}
+                    spaceBetween={16}
+                    loop={false}
+                    className="w-full"
+                    onSwiper={swiper => (swiperRef = swiper)}
+                    onSlideChange={handleSwipeAndSelectCover}
+                  >
+                    {COVER_PRESET_ASSETS.map(cover => (
+                      <SwiperSlide key={cover}>
+                        <div className="flex items-center justify-center">
+                          <CustomCoverBuilder
+                            storyTitle={title.trim() || t('placeholder_title')}
+                            authorName={userInfo?.fullName}
+                            coverImgSrc={
+                              isCustomCoverActive && selectedCoverSample === cover
+                                ? ''
+                                : cover
+                            }
+                            customization={getThumbnailCustomization(cover)}
+                            active={selectedCoverSample === cover}
+                          />
+                        </div>
+                      </SwiperSlide>
+                    ))}
+                  </Swiper>
+                  <div className="mt-3 flex justify-center space-x-2">
+                    {COVER_PRESET_ASSETS.map((cover, idx) => (
+                      <button
+                        key={cover}
+                        type="button"
+                        className={mergeClassnames(
+                          'size-2 rounded-full transition-all duration-300',
+                          currentCoverIndex === idx ? 'w-10 bg-neutral-80' : 'bg-neutral-90',
+                        )}
+                        onClick={() => swiperRef?.slideTo(idx)}
+                      />
+                    ))}
+                  </div>
+                  <Button
+                    variant="soft"
+                    size="sm"
+                    className="w-[180px]"
+                    iconRight={<PencilSimple size={16} />}
+                    onClick={() => setIsCustomCoverModalOpen(true)}
+                  >
+                    {t('custom')}
+                  </Button>
+                </div>
+              </div>
+            </div>
+            <div className="z-40 flex
+            w-full
+            bg-white
+            max-[955px]:fixed max-[955px]:bottom-0 max-[955px]:rounded-t-2xl
+            max-[955px]:p-4 max-[955px]:shadow-[0_0_4px_rgba(15,15,16,0.06)]
+            min-[955px]:mt-auto
+            min-[955px]:justify-end"
+            >
               <Button
                 type="submit"
                 size="lg"
-                className="w-[300px]"
+                className="w-full min-[955px]:w-[300px]"
                 animation={isSubmitting && 'progress'}
                 disabled={isSubmitting}
               >

--- a/src/features/stories/components/StoryForm.tsx
+++ b/src/features/stories/components/StoryForm.tsx
@@ -282,7 +282,7 @@ export default function StoryForm(props: IStoryFormProps) {
             border border-neutral-90 bg-neutral-98 p-5"
             >
               {/* Desktop */}
-              <div className="hidden w-full cursor-pointer flex-col gap-4 sm:flex">
+              <div className="hidden w-full cursor-pointer flex-col gap-4 min-[955px]:flex">
                 <div className="flex justify-between gap-2">
                   {COVER_PRESET_ASSETS.map((cover, index) => (
                     <div key={cover} className="flex flex-col gap-2">

--- a/src/features/stories/components/StoryForm.tsx
+++ b/src/features/stories/components/StoryForm.tsx
@@ -426,7 +426,7 @@ export default function StoryForm(props: IStoryFormProps) {
               )}
             </Form.Item>
             {/* Gần dưới cùng */}
-            <div className="flex flex-1 flex-col max-[955px]:px-4 min-[955px]:hidden">
+            <div className="flex flex-1 flex-col px-4 pb-24 min-[955px]:hidden">
               <p className="mb-2 text-sm font-medium text-black">
                 {t('cover_picture')}
                 {' '}


### PR DESCRIPTION
## What this PR does
- [x] Add something new
- [x] Fix some issues

## Related Issue
None

## Screenshots
Screens I have done:

Success
<img width="431" height="760" alt="fullscreen_success" src="https://github.com/user-attachments/assets/0babfff4-dadf-4307-b5a2-9c814dda9efa" />
(mobile screen)

Policy
<img width="1918" height="857" alt="desktop_fullscreen_policy" src="https://github.com/user-attachments/assets/4337149b-b7b7-429d-91fe-0323912bdcb3" />
( ^---- desktop | mobile -------V )
- made the Hero Banner responsive in most of the screen sizes
- made padding, gap, aligning changes between/on the components
<img width="427" height="755" alt="mobile_fullscreen_policy" src="https://github.com/user-attachments/assets/7ecc064d-9132-4457-8735-7c301a3f22f2" />

- added the orange warning component

Create book
<img width="270" height="587" alt="Screenshot 2026-07-13 173908" src="https://github.com/user-attachments/assets/3652d90d-0368-4bb0-8fc7-3313eab64a18" />
- moved the Cover section beneath (smaller screen)

General (for all):
+ Made the top bar and bottom bar (containing buttons) always stay on top and bottom of screen
<img width="447" height="547" alt="337x414_success" src="https://github.com/user-attachments/assets/4fd3533f-155e-425a-9048-4e6f5d13b180" />
---

**Checklist**
- [x] Code builds without errors
- [x] Changes are tested locally
- [ ] Related issue is linked (if applicable)
