### PR TITLE
fix: multiple language for email form register

### DIFF
--- a/src/app/[locale]/(unauth)/auth/register/_components/RegistrationForm.tsx
+++ b/src/app/[locale]/(unauth)/auth/register/_components/RegistrationForm.tsx
@@ -67,13 +67,20 @@ const Step1Form = ({
 
   const handleFormSubmit = handleSubmit(async (data) => {
     try {
-      await checkEmail({ email: data.email }).unwrap();
+      const result = await checkEmail({ email: data.email }).unwrap();
+      if (!result?.emailAvailable) {
+        setError('email', {
+          type: 'custom',
+          message: t('email_already_exists'),
+        });
+        return;
+      }
       onSubmit(data);
     } catch (error: any) {
       if (error?.data?.errors?.email === 'emailAlreadyExists') {
         setError('email', {
           type: 'custom',
-          message: 'Email already exists. Please use a different email',
+          message: t('email_already_exists'),
         });
       } else {
         pushError(`Error: ${error.message}`);
@@ -259,7 +266,7 @@ const Step2Form = ({
             onClick={() => handleClick('term_of_service')}
             className="font-medium leading-tight tracking-tight text-primary-50 underline"
           >
-            Terms of Use
+            {t('terms_of_use')}
           </button>
           {` ${t('accept_pp_and_tac.second')} `}
           <button
@@ -267,7 +274,7 @@ const Step2Form = ({
             onClick={() => handleClick('privacy_policy')}
             className="font-medium leading-tight tracking-tight text-primary-50 underline"
           >
-            Privacy Policy
+            {t('privacy_policy')}
           </button>
           .
         </p>
@@ -328,7 +335,7 @@ const Step3Form = (props: IStep3FormProps) => {
       if (verificationCode !== currentVerificationCode) {
         setError('verificationCode', {
           type: 'unverified',
-          message: 'The verification code is not correct, please re - enter',
+          message: t('invalid_verification_code'),
         });
       } else {
         clearErrors('verificationCode');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -565,7 +565,11 @@
     "passwords_match": "Passwords match",
     "resetting": "Resetting...",
     "back_to_login": "Back to login",
-    "submit": "Submit"
+    "submit": "Submit",
+    "email_already_exists": "Email already exists. Please use a different email",
+    "invalid_verification_code": "The verification code is not correct, please re-enter",
+    "terms_of_use": "Terms of Use",
+    "privacy_policy": "Privacy Policy"
   },
   "ForgotPassword": {
     "meta_title": "Forgot password",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -565,7 +565,11 @@
     "passwords_match": "Mật khẩu trùng khớp",
     "resetting": "Đang đặt lại...",
     "back_to_login": "Quay lại Đăng nhập",
-    "submit": "Gửi"
+    "submit": "Gửi",
+    "email_already_exists": "Email đã tồn tại. Vui lòng sử dụng email khác",
+    "invalid_verification_code": "Mã xác minh không chính xác, vui lòng nhập lại",
+    "terms_of_use": "Điều khoản sử dụng",
+    "privacy_policy": "Chính sách bảo mật"
   },
   "ForgotPassword": {
     "meta_title": "Quên mật khẩu",


### PR DESCRIPTION
What this PR does

-  Fix email validation not blocking registration when email is already taken
-  Fix hardcoded English strings in the register form (add i18n keys for en/vi)

Details:

- checkEmail on /auth/register step 1 returns HTTP 200 with { emailAvailable: false }, which is not a rejected/error response — .unwrap() resolved successfully and the form proceeded to step 2 regardless. Now the response's emailAvailable flag is checked and blocks progression with an inline error when false.
- Replaced hardcoded strings ("Email already exists...", OTP error message, "Terms of Use", "Privacy Policy") with t() calls, added corresponding keys to SignUp namespace in en.json and vi.json.
 